### PR TITLE
Added ability to specify which log should be loaded by default. When …

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,11 +38,16 @@ export function App () {
         console.debug("Version:", config.version);
         const lsTheme = localStorage.getItem("ui-theme");
         switchTheme(lsTheme === THEME_STATES.LIGHT?THEME_STATES.LIGHT:THEME_STATES.DARK);
-        if (urlSearchParams.get("filePath")) {
-            setFileInfo(urlSearchParams.get("filePath"));
+        if (config.defaultFileUrl) {
+            setFileInfo(config.defaultFileUrl);
             setAppMode(APP_STATE.FILE_VIEW);
         } else {
-            setAppMode(APP_STATE.FILE_PROMPT);
+            if (urlSearchParams.get("filePath")) {
+                setFileInfo(urlSearchParams.get("filePath"));
+                setAppMode(APP_STATE.FILE_VIEW);
+            } else {
+                setAppMode(APP_STATE.FILE_PROMPT);
+            }
         }
     }, []);
 

--- a/src/Viewer/services/utils.js
+++ b/src/Viewer/services/utils.js
@@ -52,13 +52,14 @@ const modifyPage = (action, currentPage, requestedPage, pages) => {
  */
 const modifyFileMetadata = (fileMetadata, logEventIdx) => {
     if (fileMetadata && fileMetadata.filePath) {
-        let url = `${window.location.origin}?filePath=${fileMetadata.filePath}`;
+        let url = `${window.location.origin}${window.location.pathname}`;
+        url += `?filePath=${fileMetadata.filePath}`;
         if (0 !== logEventIdx) {
             url += `#logEventIdx=${logEventIdx}`;
         }
         window.history.pushState({path: url}, "", url);
     } else if (fileMetadata && !fileMetadata.filePath) {
-        let url = `${window.location.origin}`;
+        let url = `${window.location.origin}${window.location.pathname}`;
         if (0 !== logEventIdx) {
             url += `#logEventIdx=${logEventIdx}`;
         }

--- a/src/config.json
+++ b/src/config.json
@@ -1,4 +1,5 @@
 {
   "title": "YScope Log Viewer",
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "defaultFileUrl": null
 }


### PR DESCRIPTION
…updating URL on file info change, the pathname is preserved.

# References
<!-- Any issues or pull requests relevant to this pull request -->
 - When deploying the application to the YScope landing page, the URL updates were removing the path name. 
 - When deploying the application to the YScope landing page, we need a way to indicate that this build should be a demo.

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

This request will allow the user to specify whether the build should load a demo file by default by specifying the defaultFileUrl key in config.json.

# Validation performed
<!-- What tests and validation you performed on the change -->

I have deployed the log viewer on the YScope landing page (in a local build) and the pathname is preserved on file drop. 
I have deployed the log viewer on the YScope landing page (in a local build) and verified that the demo works for the build. 

