### PR TITLE
Modified webpack so that it specifies the public path for the output.

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,7 +7,7 @@ module.exports = {
     entry: path.resolve(__dirname, "src", "index.js"),
     plugins: [
         new HtmlWebpackPlugin({
-            template: path.resolve(__dirname, "src", "index.html")
+            template: path.resolve(__dirname, "src", "index.html"),
         }),
         new MiniCssExtractPlugin(),
         new MonacoWebpackPlugin({
@@ -18,6 +18,7 @@ module.exports = {
         path: path.join(__dirname, "dist"),
         filename: "[name].[contenthash].bundle.js",
         clean: true,
+        publicPath: "./",
     },
     module: {
         rules: [


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->


# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
When publishing application to a website, if the link does not end with a /, the application is unable to load the necessary scripts. For example, www.yscope.com/log-viewer will load index.html but will be unable to find the scripts. However, www.yscope.com/log-viewer/ will be able to. To fix this, we need to set a relative path for the scripts and styles loaded into index.html.  Changing the webpack configuration will make this possible. 

# Validation performed
<!-- What tests and validation you performed on the change -->
Ran build and checked the relative path for the scripts and styles loaded into index.html.
