### PR TITLE
Bug-fix: Load logEventIdx from the URL hash parameter on load and limit it to a valid range; Preserve prettify flag in all cases (fixes #6).

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,11 +22,11 @@ export function App () {
         FILE_VIEW: 1,
     };
 
-    const urlSearchParams = new URLSearchParams(window.location.search, "?");
-
     const [fileInfo, setFileInfo] = useState(null);
     const [theme, setTheme] = useState(THEME_STATES.DARK);
     const [appMode, setAppMode] = useState(null);
+    const [prettify, setPrettify] = useState(null);
+    const [logEventIdx, setLogEventIdx] = useState(null);
 
     const switchTheme = (theme) => {
         localStorage.setItem("ui-theme", theme);
@@ -34,22 +34,46 @@ export function App () {
         setTheme(theme);
     };
 
-    useEffect(() => {
-        console.debug("Version:", config.version);
-        const lsTheme = localStorage.getItem("ui-theme");
-        switchTheme(lsTheme === THEME_STATES.LIGHT?THEME_STATES.LIGHT:THEME_STATES.DARK);
+    /**
+     * Loads the initial state of the viewer from url arguments.
+     *
+     * ### Example:
+     * localhost:3010/?filePath=/logs/sample.clp.zst&prettify=true&logEventIdx=1
+     *
+     * @return {[string,boolean,string]} [filePath,prettify,logEventIdx]
+     */
+    const getInitialStateFormUrl = () => {
+        const urlSearchParams = new URLSearchParams(window.location.search, "?");
+        const hash = window.location.hash;
+        const filePath = urlSearchParams.get("filePath");
+        const prettify = urlSearchParams.get("prettify") === "true";
+        const logEventIdx = (hash.includes("logEventIdx") ?hash.split("=").pop():null);
+        return [filePath, prettify, logEventIdx];
+    };
+
+    /**
+     * Load the file when app is rendered in this order of precedence:
+     * - Default file url is used if it is provided in config file.
+     * - File path from url if it is provided.
+     * - Provide prompt to load file.
+     */
+    const loadFileOnLoad = () => {
+        const [filePath, prettify, logEventIdx] = getInitialStateFormUrl();
+        setPrettify(prettify);
+        setLogEventIdx(logEventIdx);
+
         if (config.defaultFileUrl) {
             setFileInfo(config.defaultFileUrl);
             setAppMode(APP_STATE.FILE_VIEW);
         } else {
-            if (urlSearchParams.get("filePath")) {
-                setFileInfo(urlSearchParams.get("filePath"));
+            if (filePath) {
+                setFileInfo(filePath);
                 setAppMode(APP_STATE.FILE_VIEW);
             } else {
                 setAppMode(APP_STATE.FILE_PROMPT);
             }
         }
-    }, []);
+    };
 
     /**
      * Handles the file being changed
@@ -60,13 +84,20 @@ export function App () {
         setAppMode(APP_STATE.FILE_VIEW);
     };
 
+    useEffect(() => {
+        console.debug("Version:", config.version);
+        const lsTheme = localStorage.getItem("ui-theme");
+        switchTheme(lsTheme === THEME_STATES.LIGHT?THEME_STATES.LIGHT:THEME_STATES.DARK);
+        loadFileOnLoad();
+    }, []);
+
     return (
         <div id="app">
             <ThemeContext.Provider value={{theme, switchTheme}}>
                 <DropFile handleFileDrop={handleFileChange}>
-                    {appMode === APP_STATE.FILE_VIEW &&
-                        <Viewer logEventNumber={urlSearchParams.get("logEventIdx")}
-                            prettifyLog={urlSearchParams.get("prettify") === "true"}
+                    {(APP_STATE.FILE_VIEW === appMode) &&
+                        <Viewer logEventNumber={logEventIdx}
+                            prettifyLog={prettify}
                             fileInfo={fileInfo}/>
                     }
                 </DropFile>

--- a/src/App.js
+++ b/src/App.js
@@ -23,14 +23,18 @@ export function App () {
         FILE_VIEW: 1,
     };
 
-    const urlHashParams = new VerbatimURLParams(window.location.hash, "#");
-    const urlSearchParams = new VerbatimURLParams(window.location.search, "?");
-
     const [appMode, setAppMode] = useState(null);
     const [fileInfo, setFileInfo] = useState(null);
     const [logEventIdx, setLogEventIdx] = useState(null);
     const [prettify, setPrettify] = useState(null);
     const [theme, setTheme] = useState(THEME_STATES.DARK);
+
+    useEffect(() => {
+        console.debug("Version:", config.version);
+        const lsTheme = localStorage.getItem("ui-theme");
+        switchTheme(THEME_STATES.LIGHT === lsTheme ?THEME_STATES.LIGHT :THEME_STATES.DARK);
+        init();
+    }, []);
 
     const switchTheme = (theme) => {
         localStorage.setItem("ui-theme", theme);
@@ -39,22 +43,28 @@ export function App () {
     };
 
     /**
-     * Loads the file when app is rendered in this order of precedence:
-     * - File path from url if it is provided.
-     * - Default file url is used if it is provided in config file.
-     * - Provide prompt to load file.
+     * Initializes the application's state. The file to load is set based on
+     * this order of precedence:
+     * <ul>
+     *   <li>`filePath` from url if it is provided</li>
+     *   <li>`defaultFileUrl` if it is provided in config file</li>
+     * </ul>
+     * If neither are provided, we display a prompt to load a file.
      */
     const init = () => {
+        const urlHashParams = new VerbatimURLParams(window.location.hash, "#");
+        const urlSearchParams = new VerbatimURLParams(window.location.search, "?");
+
         // Load the initial state of the viewer from url
         setPrettify(urlSearchParams.get("prettify") === "true");
         setLogEventIdx(urlHashParams.get("logEventIdx"));
 
         const filePath = urlSearchParams.get("filePath");
-        if (filePath) {
+        if (undefined !== filePath) {
             setFileInfo(filePath);
             setAppMode(APP_STATE.FILE_VIEW);
         } else {
-            if (config.defaultFileUrl) {
+            if (null !== config.defaultFileUrl) {
                 setFileInfo(config.defaultFileUrl);
                 setAppMode(APP_STATE.FILE_VIEW);
             } else {
@@ -71,13 +81,6 @@ export function App () {
         setFileInfo(file);
         setAppMode(APP_STATE.FILE_VIEW);
     };
-
-    useEffect(() => {
-        console.debug("Version:", config.version);
-        const lsTheme = localStorage.getItem("ui-theme");
-        switchTheme(THEME_STATES.LIGHT === lsTheme? THEME_STATES.LIGHT: THEME_STATES.DARK);
-        init();
-    }, []);
 
     return (
         <div id="app">

--- a/src/Viewer/README.md
+++ b/src/Viewer/README.md
@@ -35,11 +35,11 @@ const App = () => {
         FILE_VIEW: 1,
     };
 
-    const urlSearchParams = new URLSearchParams(window.location.search, "?");
-
     const [fileInfo, setFileInfo] = useState(null);
     const [theme, setTheme] = useState(THEME_STATES.DARK);
-    const [appMode, setAppMode] = useState();
+    const [appMode, setAppMode] = useState(null);
+    const [prettify, setPrettify] = useState(null);
+    const [logEventIdx, setLogEventIdx] = useState(null);
 
     const switchTheme = (theme) => {
         localStorage.setItem("ui-theme", theme);
@@ -47,30 +47,70 @@ const App = () => {
         setTheme(theme);
     };
 
+    /**
+     * Loads the initial state of the viewer from url arguments.
+     *
+     * ### Example:
+     * localhost:3010/?filePath=/logs/sample.clp.zst&prettify=true&logEventIdx=1
+     *
+     * @return {[string,boolean,string]} [filePath,prettify,logEventIdx]
+     */
+    const getInitialStateFormUrl = () => {
+        const urlSearchParams = new URLSearchParams(window.location.search, "?");
+        const hash = window.location.hash;
+        const filePath = urlSearchParams.get("filePath");
+        const prettify = urlSearchParams.get("prettify") === "true";
+        const logEventIdx = (hash.includes("logEventIdx") ?hash.split("=").pop():null);
+        return [filePath, prettify, logEventIdx];
+    };
+
+    /**
+     * Load the file when app is rendered in this order of precedence:
+     * - Default file url is used if it is provided in config file.
+     * - File path from url if it is provided.
+     * - Provide prompt to load file.
+     */
+    const loadFileOnLoad = () => {
+        const [filePath, prettify, logEventIdx] = getInitialStateFormUrl();
+        setPrettify(prettify);
+        setLogEventIdx(logEventIdx);
+
+        if (config.defaultFileUrl) {
+            setFileInfo(config.defaultFileUrl);
+            setAppMode(APP_STATE.FILE_VIEW);
+        } else {
+            if (filePath) {
+                setFileInfo(filePath);
+                setAppMode(APP_STATE.FILE_VIEW);
+            } else {
+                setAppMode(APP_STATE.FILE_PROMPT);
+            }
+        }
+    };
+
+    /**
+     * Handles the file being changed
+     * @param {File} file
+     */
     const handleFileChange = (file) => {
         setFileInfo(file);
         setAppMode(APP_STATE.FILE_VIEW);
     };
-    
+
     useEffect(() => {
         console.debug("Version:", config.version);
         const lsTheme = localStorage.getItem("ui-theme");
-        switchTheme(lsTheme === THEME_STATES.LIGHT ? THEME_STATES.LIGHT : THEME_STATES.DARK);
-        if (urlSearchParams.get("filePath")) {
-            setFileInfo(urlSearchParams.get("filePath"));
-            setAppMode(APP_STATE.FILE_VIEW);
-        } else {
-            setAppMode(APP_STATE.FILE_PROMPT);
-        }
+        switchTheme(lsTheme === THEME_STATES.LIGHT?THEME_STATES.LIGHT:THEME_STATES.DARK);
+        loadFileOnLoad();
     }, []);
 
     return (
         <div id="app">
             <ThemeContext.Provider value={{theme, switchTheme}}>
                 <DropFile handleFileDrop={handleFileChange}>
-                    {appMode === APP_STATE.VIEWER &&
-                        <Viewer logEventNumber={urlSearchParams.get("logEventIdx")}
-                            prettifyLog={urlSearchParams.get("prettify") === "true"}
+                    {(APP_STATE.FILE_VIEW === appMode) &&
+                        <Viewer logEventNumber={logEventIdx}
+                            prettifyLog={prettify}
                             fileInfo={fileInfo}/>
                     }
                 </DropFile>

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -232,6 +232,8 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber}) {
         const logEventIdx = urlHashParams.get("logEventIdx");
         if (isNumeric(logEventIdx)) {
             changeState(STATE_CHANGE_TYPE.logEventIdx, {logEventIdx: Number(logEventIdx)});
+        } else {
+            changeState(STATE_CHANGE_TYPE.logEventIdx, {logEventIdx: logFileState.logEventIdx});
         }
     };
 

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -55,7 +55,7 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber}) {
         pages: null,
         page: null,
         prettify: prettifyLog ? prettifyLog : false,
-        logEventIdx: isNumeric(logEventNumber) ? logEventNumber : null,
+        logEventIdx: isNumeric(logEventNumber) ? Number(logEventNumber) : null,
         lineNumber: null,
         columnNumber: null,
         colNumber: null,
@@ -170,14 +170,12 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber}) {
                 });
                 break;
             case STATE_CHANGE_TYPE.logEventIdx:
-                if (args.logEventIdx) {
-                    setLoadingLogs(true);
-                    setStatusMessage(`Going to new log event ${args.logEventIdx}`);
-                    clpWorker.current.postMessage({
-                        code: CLP_WORKER_PROTOCOL.GET_LINE_FROM_EVENT,
-                        desiredLogEventIdx: Number(args.logEventIdx),
-                    });
-                }
+                setLoadingLogs(true);
+                setStatusMessage(`Going to new log event ${args.logEventIdx}`);
+                clpWorker.current.postMessage({
+                    code: CLP_WORKER_PROTOCOL.GET_LINE_FROM_EVENT,
+                    desiredLogEventIdx: args.logEventIdx,
+                });
                 break;
             default:
                 break;
@@ -232,7 +230,9 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber}) {
     window.onhashchange = () => {
         const urlHashParams = new VerbatimURLParams(window.location.hash, "#");
         const logEventIdx = urlHashParams.get("logEventIdx");
-        changeState(STATE_CHANGE_TYPE.logEventIdx, {logEventIdx: logEventIdx});
+        if (isNumeric(logEventIdx)) {
+            changeState(STATE_CHANGE_TYPE.logEventIdx, {logEventIdx: Number(logEventIdx)});
+        }
     };
 
     return (

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -264,7 +264,8 @@ class FileManager {
             this._filterLogEvents(-1);
 
             const numberOfEvents = this._logEventOffsets.length;
-            if (!this._state.logEventIdx || this._state.logEventIdx > numberOfEvents) {
+            if (null === this._state.logEventIdx || this._state.logEventIdx > numberOfEvents ||
+                this._state.logEventIdx <= 0) {
                 this._state.logEventIdx = numberOfEvents;
             }
 

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -263,8 +263,9 @@ class FileManager {
             this._buildIndex();
             this._filterLogEvents(-1);
 
-            if (!this._state.logEventIdx) {
-                this._state.logEventIdx = this._logEventOffsets.length;
+            const numberOfEvents = this._logEventOffsets.length;
+            if (!this._state.logEventIdx || this._state.logEventIdx > numberOfEvents) {
+                this._state.logEventIdx = numberOfEvents;
             }
 
             this._createPages();

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -156,8 +156,10 @@ class FileManager {
         }
         if (logEventIdx > this._state.numberOfEvents) {
             console.debug("Log event provided was larger than the number of events.");
-            console.debug(`Log event was limited to ${this._state.numberOfEvents}`);
-            this._state.logEventIdx = this._state.numberOfEvents;
+            this._updateStateCallback(CLP_WORKER_PROTOCOL.UPDATE_STATE, this._state);
+        } else if (logEventIdx <= 0) {
+            console.debug("Log event provided was less than or equal to zero.");
+            this._updateStateCallback(CLP_WORKER_PROTOCOL.UPDATE_STATE, this._state);
         } else {
             this._state.logEventIdx = logEventIdx;
         }

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -156,10 +156,8 @@ class FileManager {
         }
         if (logEventIdx > this._state.numberOfEvents) {
             console.debug("Log event provided was larger than the number of events.");
-            this._updateStateCallback(CLP_WORKER_PROTOCOL.UPDATE_STATE, this._state);
         } else if (logEventIdx <= 0) {
             console.debug("Log event provided was less than or equal to zero.");
-            this._updateStateCallback(CLP_WORKER_PROTOCOL.UPDATE_STATE, this._state);
         } else {
             this._state.logEventIdx = logEventIdx;
         }


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

#6 

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

This PR fixes a few issues including #6:
- On page load, the log event number was being loaded from the search parameters instead of the hash parameter. This is an issue because the generated URL to a specific event indicates the log event number in the hash parameter.
- When loading file from defaultFileURL in config.json, the provided log event number was not being preserved. This is relevant in the case where a demo is running but the we want to share a link to a specific event in the file.
- In the event that the provided log event is greater than the maximum number of events, the number of events was not being limited. Even worse, this number was being displayed in the UI.
- The prettify flag was not being set when a demo file was being loaded from and when using drag & drop.

The fixes are:
- Log event is now loaded from hash parameters.
- The prettify flag and provided log event number are preserved in all use cases. 
- The log event loaded is now limited to the number of events in the file and this change is reflected in the UI.

# Validation performed
<!-- What tests and validation you performed on the change -->

Tested these configurations:
- Loaded file from defaultFileUrl and checked if prettify and logEvent are loaded from URL. Also set the logEventIdx to be greater than the number of events in the provided file and verified that it was reset to the number of events.
- Loaded file from filePath and checked if prettify and logEvent are loaded from URL. Also set the logEventIdx to be greater than the number of events in the provided file and verified that number of events was limited. 
- Loaded file from drag and drop element and verified that the logEventIdx goes to the last event in the file. Verified that the prettify flag is preserved on drag and drop.
