### PR TITLE
Bug-fix: Ignore commas outside bracketed regions when prettifying (fixes #11).

### DIFF
--- a/src/Viewer/services/decoder/SimplePrettifier.js
+++ b/src/Viewer/services/decoder/SimplePrettifier.js
@@ -39,8 +39,8 @@ class SimplePrettifier {
         - After seeing '\', we ignore the next character.
         - After seeing '"', we only monitor for an unescaped '"'.
         - After seeing '\'', we only monitor for an unescaped '\''.
-            - After seeing '{'/'(', we *typically* add a newline and increase
-              the indentation level.
+        - After seeing '{'/'(', we *typically* add a newline and increase
+          the indentation level.
             - The one exception to this is if there is only one
               parameter/kv-pair in the region enclosed by "{}"/"()". However,
               this is hard to determine without reading ahead until the end of
@@ -110,6 +110,12 @@ class SimplePrettifier {
                 --squareBracketsLevel;
                 arrayIndentLevels.pop();
             } else if ("," === c) {
+                if (0 === squareBracketsLevel && 0 === indentLevel) {
+                    // Comma is not within a bracketed region, so it doesn't
+                    // need handling
+                    continue;
+                }
+
                 if (lineBreakPending) {
                     newString += this._getStartingWhitespaceOfNewLine(indentLevel);
                     lineBreakPending = false;


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#11

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
Commas were erroneously being handled inside and *outside* bracketed regions. This PR fixes that.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Prettified the log event mentioned in #11 and verified that it was unaffected.
* Prettified some JSON logs and verified that they were the same before and after this change.

