### PR TITLE
Bug Fix: Webpack publicPath output configuration was updated to auto.…

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -18,7 +18,7 @@ module.exports = {
         path: path.join(__dirname, "dist"),
         filename: "[name].[contenthash].bundle.js",
         clean: true,
-        publicPath: "./",
+        publicPath: "auto",
     },
     module: {
         rules: [


### PR DESCRIPTION
… Previous value of "./" was causing build issues.

# References
<!-- Any issues or pull requests relevant to this pull request -->
https://github.com/y-scope/yscope-log-viewer/issues/10

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
When running NPM start or NPM build, the output publicPath value of "./" was causing an issue where the route could not be found. However, this issue wouldn't have been seen in the build, since index.html would be in the same folder as the script files. Changing publicPath to "auto" fixed both use cases.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Cloned a fresh repo, changed publicPath to "auto" and ran a dev server, the application loaded successfully. 
- Cloned a fresh repo, changed publicPath to "auto" and ran a build, the build ran successfully and the application loaded.
