### PR TITLE
Modified the FourByteClpIrStreamProtocolDecoder so that when reading …

### DIFF
--- a/src/Viewer/services/decoder/DataInputStream.js
+++ b/src/Viewer/services/decoder/DataInputStream.js
@@ -86,6 +86,19 @@ class DataInputStream {
     }
 
     /**
+     * Reads an unsigned byte
+     * @return {number} The read byte
+     */
+    readSignedByte () {
+        const requiredLen = this._byteIx + 1;
+        if (this._dataView.byteLength < requiredLen) {
+            this._byteIx = this._dataView.byteLength;
+            throw new DataInputStreamEOFError(this._dataView.byteLength, requiredLen);
+        }
+        return this._dataView.getInt8(this._byteIx++);
+    }
+
+    /**
      * Reads an unsigned short
      * @return {number} The read short
      */
@@ -96,6 +109,21 @@ class DataInputStream {
             throw new DataInputStreamEOFError(this._dataView.byteLength, requiredLen);
         }
         const val = this._dataView.getUint16(this._byteIx, false);
+        this._byteIx += 2;
+        return val;
+    }
+
+    /**
+     * Reads an unsigned short
+     * @return {number} The read short
+     */
+    readSignedShort () {
+        const requiredLen = this._byteIx + 2;
+        if (this._dataView.byteLength < requiredLen) {
+            this._byteIx = this._dataView.byteLength;
+            throw new DataInputStreamEOFError(this._dataView.byteLength, requiredLen);
+        }
+        const val = this._dataView.getInt16(this._byteIx, false);
         this._byteIx += 2;
         return val;
     }

--- a/src/Viewer/services/decoder/DataInputStream.js
+++ b/src/Viewer/services/decoder/DataInputStream.js
@@ -86,7 +86,7 @@ class DataInputStream {
     }
 
     /**
-     * Reads an unsigned byte
+     * Reads a signed byte
      * @return {number} The read byte
      */
     readSignedByte () {
@@ -114,7 +114,7 @@ class DataInputStream {
     }
 
     /**
-     * Reads an unsigned short
+     * Reads a signed short
      * @return {number} The read short
      */
     readSignedShort () {

--- a/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
+++ b/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
@@ -110,10 +110,10 @@ class FourByteClpIrStreamProtocolDecoder {
         let timestampDelta;
         switch (this.readTag(dataInputStream)) {
             case PROTOCOL.PAYLOAD.TIMESTAMP_DELTA_SIGNED_BYTE:
-                timestampDelta = dataInputStream.readUnsignedByte();
+                timestampDelta = dataInputStream.readSignedByte();
                 break;
             case PROTOCOL.PAYLOAD.TIMESTAMP_DELTA_SIGNED_SHORT:
-                timestampDelta = dataInputStream.readUnsignedShort();
+                timestampDelta = dataInputStream.readSignedShort();
                 break;
             case PROTOCOL.PAYLOAD.TIMESTAMP_DELTA_SIGNED_INT:
                 timestampDelta = dataInputStream.readInt();


### PR DESCRIPTION
…timestamp, it reads signed bytes and signed shorts. This accounts for cases where the timestamp might not be in ascending order.

# References
#16 

# Description
When timestamps are out order with log events, the viewer was displaying incorrect timestamps. This was because when reading the timestamps, the viewer was reading the timestamps deltas as an unsigned values. This resulted in an incorrect timestamp when the delta was negative. 

This fix modifies the viewer to read the timestamp deltas as signed numbers. This results in the proper calculations for the timestamp. 

# Validation performed
IRStream encoded a log file in the hive-24 dataset which has timestamps that are out of order. Opened the IRStream file in the log viewer and confirmed that the timestamps matched with the original log file. 
