### PR TITLE
Bug-fix: Account for JavaScript's handling of bitwise operations on integers when decoding float values (fixes #18).

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ are rendered to the UI.
 
 # Validation
 
-Currently, there is no automated testing to verify that changes don't cause 
+Currently, there is limited automated testing to verify that changes don't cause 
 bugs. While this is being developed, the following tests can be run manually:
 
 * Verify that the following features work:
@@ -102,6 +102,15 @@ bugs. While this is being developed, the following tests can be run manually:
   * Prettifying logs 
   * Using the keyboard shortcuts
 * Perform a build and verify that all features are functional
+
+## Running tests
+
+We use [`jest`](https://jestjs.io/docs/getting-started) as our testing
+framework. Tests can be run with:
+
+```shell
+npm test
+```
 
 # Features in Development
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./src/index.js",
   "scripts": {
     "build": "webpack --config webpack.prod.js",
-    "start": "webpack serve --open --config webpack.dev.js"
+    "start": "webpack serve --open --config webpack.dev.js",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -19,8 +20,8 @@
   "homepage": "https://github.com/y-scope/yscope-log-viewer#readme",
   "dependencies": {
     "@monaco-editor/react": "^4.4.6",
-    "buffer": "^6.0.3",
     "bootstrap": "^5.2.3",
+    "buffer": "^6.0.3",
     "compression-webpack-plugin": "^10.0.0",
     "crypto-browserify": "^3.12.0",
     "css-unicode-loader": "^1.0.3",
@@ -30,9 +31,9 @@
     "process": "^0.11.10",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "react-bootstrap": "^2.5.0",
     "react-bootstrap-icons": "^1.10.2",
+    "react-dom": "^18.2.0",
     "react-loading-icons": "^1.1.0",
     "react-monaco-editor": "^0.50.1",
     "react-router-dom": "^6.4.3",
@@ -50,6 +51,7 @@
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "file-loader": "^6.2.0",
+    "jest": "^29.5.0",
     "mini-css-extract-plugin": "^2.6.1",
     "sass": "^1.55.0",
     "sass-loader": "^13.1.0",

--- a/src/Viewer/services/decoder/FourByteVarBuf.js
+++ b/src/Viewer/services/decoder/FourByteVarBuf.js
@@ -3,7 +3,7 @@ import {javaIntegerDivide} from "./utils";
 
 class FourByteVarBuf extends AbstractBuf {
     static NON_DICT_VAR_MAXIMUM_LENGTH_AS_STRING = 11;
-    static INTEGER_MAX_VALUE = (2 ** 32) - 1;
+    static ENCODED_FLOAT_DIGITS_BIT_MASK = (1 << 25) - 1;
     static HYPHEN_CHAR_CODE = "-".charCodeAt(0);
     static PERIOD_CHAR_CODE = ".".charCodeAt(0);
     static ZERO_CHAR_CODE = "0".charCodeAt(0);
@@ -19,28 +19,33 @@ class FourByteVarBuf extends AbstractBuf {
         this._signedIntBackedEncoding = signedIntBackedEncoding;
     }
 
+    /**
+     * Decodes the given encoded integer variable into a string. This is a
+     * JavaScript equivalent of the decoding method from our
+     * [core](https://github.com/y-scope/clp) in C++.
+     */
     decodeAsIntegerType () {
         // Compute number of digits in a tight loop to minimize branching cost
         // later on
-        let val = this._signedIntBackedEncoding;
+        let encodedInt = this._signedIntBackedEncoding;
         let numDigits = 0;
         do {
             ++numDigits;
-            val = javaIntegerDivide(val, 10);
-        } while (0 !== val);
-        let endOffset = numDigits;
+            encodedInt = javaIntegerDivide(encodedInt, 10);
+        } while (0 !== encodedInt);
+        let endPos = numDigits;
 
         const bytes = new Uint8Array(this._decodedValueArrayBuffer);
 
         // Decode value into buffer efficiently by working with positive modulus
         // if possible
-        val = this._signedIntBackedEncoding;
+        encodedInt = this._signedIntBackedEncoding;
         let digitsBeginPos = 0;
         let i = numDigits - 1;
-        if (val < 0) {
+        if (encodedInt < 0) {
             // Add negative sign
             bytes[0] = FourByteVarBuf.HYPHEN_CHAR_CODE;
-            ++endOffset;
+            ++endPos;
             ++digitsBeginPos;
             ++i;
 
@@ -49,65 +54,72 @@ class FourByteVarBuf extends AbstractBuf {
             // NOTE: We can't convert the value to positive immediately since
             // the largest representable negative number is (at the time of
             // writing) one more than the largest representable positive number
-            bytes[i--] = (FourByteVarBuf.ZERO_CHAR_CODE + ((val % 10) * -1));
-            val = javaIntegerDivide(val, -10);
+            bytes[i--] = (FourByteVarBuf.ZERO_CHAR_CODE + ((encodedInt % 10) * -1));
+            encodedInt = javaIntegerDivide(encodedInt, -10);
         }
         for (; i >= digitsBeginPos; --i) {
-            bytes[i] = (FourByteVarBuf.ZERO_CHAR_CODE + val % 10);
-            val = javaIntegerDivide(val, 10);
+            bytes[i] = (FourByteVarBuf.ZERO_CHAR_CODE + encodedInt % 10);
+            encodedInt = javaIntegerDivide(encodedInt, 10);
         }
 
-        this._valueUint8Array = bytes.subarray(0, endOffset);
+        this._valueUint8Array = bytes.subarray(0, endPos);
     }
 
+    /**
+     * Decodes the given encoded float variable into a string. This is a
+     * JavaScript equivalent of the decoding method from our
+     * [core](https://github.com/y-scope/clp) in C++.
+     */
     decodeAsFloatType () {
         const bytes = new Uint8Array(this._decodedValueArrayBuffer);
 
-        let endOffset = 0;
-        if (this._signedIntBackedEncoding < 0) {
-            bytes[endOffset++] = FourByteVarBuf.HYPHEN_CHAR_CODE;
-        }
+        let encodedFloat = this._signedIntBackedEncoding;
+        const decimalPointPosFromRight = (encodedFloat & 0x07) + 1;
+        encodedFloat >>= 3;
+        const numDigits = (encodedFloat & 0x07) + 1;
+        encodedFloat >>= 3;
+        let digits = encodedFloat & FourByteVarBuf.ENCODED_FLOAT_DIGITS_BIT_MASK;
+        encodedFloat >>= 25;
+        const isNegative = encodedFloat & 0x1;
 
-        // Bits 3-5 are # of decimal digits minus 1
-        const numDigits = ((this._signedIntBackedEncoding & 0x038) >> 3) + 1;
-
-        // + 1 to include the decimal point
-        let numCharsRemaining = numDigits + 1;
-        endOffset += numCharsRemaining;
-
-        // Bits 0-2 are the offset of the decimal from the right minus 1
-        let decimalPointOffset = (this._signedIntBackedEncoding & 0x07) + 1;
-        // Make decimalPointOffset relative to the left
-        decimalPointOffset = endOffset - 1 - decimalPointOffset;
+        // +1 for the decimal point
+        const valueLength = isNegative + numDigits + 1;
+        let numCharsToProcess = valueLength;
 
         // Decode until the decimal point or the non-zero digits are exhausted
-        let digits = (this._signedIntBackedEncoding & FourByteVarBuf.INTEGER_MAX_VALUE) >> 6;
-        let offset = endOffset - 1;
-        for (; offset > decimalPointOffset; --offset) {
-            bytes[offset] = FourByteVarBuf.ZERO_CHAR_CODE + (digits % 10);
+        let pos = valueLength - 1;
+        const decimalPointPos = valueLength - 1 - decimalPointPosFromRight;
+        for (; pos > decimalPointPos && digits > 0; --pos) {
+            bytes[pos] = FourByteVarBuf.ZERO_CHAR_CODE + (digits % 10);
             digits = javaIntegerDivide(digits, 10);
-            --numCharsRemaining;
+            --numCharsToProcess;
         }
 
         if (digits > 0) {
             // Skip decimal point since it's added at the end
-            --offset;
-            --numCharsRemaining;
+            --pos;
+            --numCharsToProcess;
 
             while (digits > 0) {
-                bytes[offset--] = FourByteVarBuf.ZERO_CHAR_CODE + (digits % 10);
+                bytes[pos--] = FourByteVarBuf.ZERO_CHAR_CODE + (digits % 10);
                 digits = javaIntegerDivide(digits, 10);
-                --numCharsRemaining;
+                --numCharsToProcess;
             }
         }
 
         // Add remaining zeros
-        bytes.fill(FourByteVarBuf.ZERO_CHAR_CODE, offset + 1 - numCharsRemaining, offset + 1);
+        bytes.fill(FourByteVarBuf.ZERO_CHAR_CODE, isNegative, numCharsToProcess);
 
         // Add decimal
-        bytes[decimalPointOffset] = FourByteVarBuf.PERIOD_CHAR_CODE;
+        bytes[decimalPointPos] = FourByteVarBuf.PERIOD_CHAR_CODE;
 
-        this._valueUint8Array = bytes.subarray(0, endOffset);
+        // Add sign
+        if (isNegative) {
+            bytes[0] = FourByteVarBuf.HYPHEN_CHAR_CODE;
+            --numCharsToProcess;
+        }
+
+        this._valueUint8Array = bytes.subarray(0, valueLength);
     }
 }
 

--- a/src/Viewer/services/decoder/FourByteVarBuf.test.js
+++ b/src/Viewer/services/decoder/FourByteVarBuf.test.js
@@ -1,0 +1,79 @@
+import FourByteVarBuf from "./FourByteVarBuf";
+
+// This file tests the encoded-variable decoding methods by using values that
+// have already been encoded (the alternative being to take a string, encode
+// it, decode it, and compare the original and decoded strings). This is so we
+// can avoid duplicating the encoding methods in another language besides our
+// core in C++ (https://github.com/y-scope/clp). In fact, the eventual goal is
+// to replace the JavaScript decoding methods with bindings to our C++ core.
+// The tests and encoded values below are copied from our C++ core.
+
+test("decodeAsIntegerType", () => {
+    const textDecoder = new TextDecoder();
+    const varBuf = new FourByteVarBuf();
+
+    // Basic conversions
+    varBuf.setFourByteVariableEncoding(0);
+    varBuf.decodeAsIntegerType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("0");
+
+    varBuf.setFourByteVariableEncoding(-1);
+    varBuf.decodeAsIntegerType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("-1");
+
+    varBuf.setFourByteVariableEncoding(1);
+    varBuf.decodeAsIntegerType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("1");
+
+    // Edges of representable range
+    varBuf.setFourByteVariableEncoding(-(2 ** 31));
+    varBuf.decodeAsIntegerType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("-2147483648");
+
+    varBuf.setFourByteVariableEncoding((2 ** 31) - 1);
+    varBuf.decodeAsIntegerType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("2147483647");
+});
+
+test("decodeAsFloatType", () => {
+    const textDecoder = new TextDecoder();
+    const varBuf = new FourByteVarBuf();
+
+    // Basic conversions
+    varBuf.setFourByteVariableEncoding(0x8);
+    varBuf.decodeAsFloatType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("0.0");
+
+    varBuf.setFourByteVariableEncoding(0x80000288);
+    varBuf.decodeAsFloatType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("-1.0");
+
+    varBuf.setFourByteVariableEncoding(0x288);
+    varBuf.decodeAsFloatType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("1.0");
+
+    varBuf.setFourByteVariableEncoding(0x40);
+    varBuf.decodeAsFloatType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe(".1");
+
+    // Edges of representable range
+    varBuf.setFourByteVariableEncoding(0x80000019);
+    varBuf.decodeAsFloatType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("-00.00");
+
+    varBuf.setFourByteVariableEncoding(0xfffffff8);
+    varBuf.decodeAsFloatType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("-3355443.1");
+
+    varBuf.setFourByteVariableEncoding(0x7ffffff8);
+    varBuf.decodeAsFloatType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("3355443.1");
+
+    varBuf.setFourByteVariableEncoding(0xffffffff);
+    varBuf.decodeAsFloatType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe("-.33554431");
+
+    varBuf.setFourByteVariableEncoding(0x7fffffff);
+    varBuf.decodeAsFloatType();
+    expect(textDecoder.decode(varBuf.getValueUint8Array())).toBe(".33554431");
+});


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#18

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

* The variable decoding logic was ported without considering the nuances of JavaScript's handling of bitwise operations on integers: Specifically, JavaScript [converts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise_operators) operands to 32-bit values when doing bitwise operations on them.
* This PR resolves the issue and makes the code look more like the C++ code it's based on.
* This PR also adds unit tests for the decoding logic.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Validated the new unit tests pass.
* Validated that a problematic IR stream now decoded the float values correctly.
