### PR TITLE
Bug Fix: When changing the log event in the hash mark, an outdated fu…

### DIFF
--- a/src/Viewer/services/ActionHandler.js
+++ b/src/Viewer/services/ActionHandler.js
@@ -116,7 +116,7 @@ class ActionHandler {
         if (currentPage !== this._logFile.state.page) {
             this._logFile.decodePage();
         }
-        this._logFile.getLineNumberOfLogEvent();
+        this._logFile.computeLineNumFromLogEventIdx();
         this._updateStateCallback(CLP_WORKER_PROTOCOL.UPDATE_STATE, this._logFile.state);
     };
 


### PR DESCRIPTION
…nction was being called to compute line number from log event.

# References
#20 

# Description
In a previous commit (#15) , an outdated function was being called when the hash value for log event Idx was changed. The function names were updated for clarity but this change wasn't properly propagated through the whole file.

# Validation performed
Opened an IRStream file, manually modified the hash value for logEventIdx and verified that the UI updated to go to the chosen event. 

