### PR TITLE
Specify timestamp in the URL search parameter.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,7 @@ module.exports = {
         "key-spacing": "warn",
         "keyword-spacing": "warn",
         "max-len": ["warn", {
-            "code": 99,
+            "code": 100,
             "comments": 80,
             "ignoreComments": false,
             "ignoreTrailingComments": false,

--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,7 @@ export function App () {
     const [appMode, setAppMode] = useState(null);
     const [fileInfo, setFileInfo] = useState(null);
     const [logEventIdx, setLogEventIdx] = useState(null);
+    const [timestamp, setTimestamp] = useState(null);
     const [prettify, setPrettify] = useState(null);
     const [theme, setTheme] = useState(THEME_STATES.DARK);
 
@@ -58,6 +59,7 @@ export function App () {
         // Load the initial state of the viewer from url
         setPrettify(urlSearchParams.get("prettify") === "true");
         setLogEventIdx(urlHashParams.get("logEventIdx"));
+        setTimestamp(urlSearchParams.get("timestamp"));
 
         const filePath = urlSearchParams.get("filePath");
         if (undefined !== filePath) {
@@ -88,6 +90,7 @@ export function App () {
                 <DropFile handleFileDrop={handleFileChange}>
                     {(APP_STATE.FILE_VIEW === appMode) &&
                         <Viewer logEventNumber={logEventIdx}
+                            timestamp={timestamp}
                             prettifyLog={prettify}
                             fileInfo={fileInfo}/>
                     }

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -32,7 +32,8 @@ Viewer.propTypes = {
  * @param {File|String} fileInfo File object to read or file path to load
  * @param {boolean} prettifyLog Whether to prettify the log file
  * @param {Number} logEventNumber The initial log event number
- * @param {Number} timestamp The minimum timestamp initially to show
+ * @param {Number} timestamp The initial timestamp to show. If this field is
+ * valid, logEventNumber will be ignored.
  * @return {JSX.Element}
  */
 export function Viewer ({fileInfo, prettifyLog, logEventNumber, timestamp}) {
@@ -93,13 +94,13 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber, timestamp}) {
         clpWorker.current.onmessage = handleWorkerMessage;
         // If file was loaded using file dialog or drag/drop, reset logEventIdx
         const logEvent = (typeof fileInfo === "string") ? logFileState.logEventIdx : null;
-        const initTimestamp = isNumeric(timestamp) ? Number(timestamp) : null;
+        const initialTimestamp = isNumeric(timestamp) ? Number(timestamp) : null;
         clpWorker.current.postMessage({
             code: CLP_WORKER_PROTOCOL.LOAD_FILE,
             fileInfo: fileInfo,
             prettify: logFileState.prettify,
             logEventIdx: logEvent,
-            initTimestamp: initTimestamp,
+            initialTimestamp: initialTimestamp,
             pageSize: logFileState.pageSize,
         });
     };

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -23,6 +23,7 @@ Viewer.propTypes = {
     filePath: PropTypes.string,
     prettifyLog: PropTypes.bool,
     logEventNumber: PropTypes.string,
+    timestamp: PropTypes.string,
 };
 
 /**
@@ -31,9 +32,10 @@ Viewer.propTypes = {
  * @param {File|String} fileInfo File object to read or file path to load
  * @param {boolean} prettifyLog Whether to prettify the log file
  * @param {Number} logEventNumber The initial log event number
+ * @param {Number} timestamp The minimum timestamp initially to show
  * @return {JSX.Element}
  */
-export function Viewer ({fileInfo, prettifyLog, logEventNumber}) {
+export function Viewer ({fileInfo, prettifyLog, logEventNumber, timestamp}) {
     const {theme} = useContext(ThemeContext);
 
     // Ref hook used to reference worker used for loading and decoding
@@ -91,11 +93,13 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber}) {
         clpWorker.current.onmessage = handleWorkerMessage;
         // If file was loaded using file dialog or drag/drop, reset logEventIdx
         const logEvent = (typeof fileInfo === "string") ? logFileState.logEventIdx : null;
+        const initTimestamp = isNumeric(timestamp) ? Number(timestamp) : null;
         clpWorker.current.postMessage({
             code: CLP_WORKER_PROTOCOL.LOAD_FILE,
             fileInfo: fileInfo,
             prettify: logFileState.prettify,
             logEventIdx: logEvent,
+            initTimestamp: initTimestamp,
             pageSize: logFileState.pageSize,
         });
     };

--- a/src/Viewer/services/ActionHandler.js
+++ b/src/Viewer/services/ActionHandler.js
@@ -23,7 +23,7 @@ class ActionHandler {
      */
     constructor (fileInfo, prettify, logEventIdx, initialTimestamp, pageSize) {
         this._logFile = new FileManager(fileInfo, prettify, logEventIdx, initialTimestamp, pageSize,
-            this._loadingMessageCallback, this._updateStateCallback, this._updateLogsCallback, 
+            this._loadingMessageCallback, this._updateStateCallback, this._updateLogsCallback,
             this._updateFileInfoCallback);
         this._logFile.decompressAndLoadFile();
     }

--- a/src/Viewer/services/ActionHandler.js
+++ b/src/Viewer/services/ActionHandler.js
@@ -18,11 +18,13 @@ class ActionHandler {
      * @param {String|File} fileInfo
      * @param {boolean} prettify
      * @param {Number} logEventIdx
+     * @param {Number} initTimestamp
      * @param {Number} pageSize
      */
-    constructor (fileInfo, prettify, logEventIdx, pageSize) {
+    constructor (fileInfo, prettify, logEventIdx, initTimestamp, pageSize) {
         this._logFile = new FileManager(fileInfo, prettify,
-            logEventIdx, pageSize, this._loadingMessageCallback, this._updateStateCallback,
+            logEventIdx, initTimestamp, pageSize,
+            this._loadingMessageCallback, this._updateStateCallback,
             this._updateLogsCallback, this._updateFileInfoCallback);
         this._logFile.decompressAndLoadFile();
     }

--- a/src/Viewer/services/ActionHandler.js
+++ b/src/Viewer/services/ActionHandler.js
@@ -18,14 +18,13 @@ class ActionHandler {
      * @param {String|File} fileInfo
      * @param {boolean} prettify
      * @param {Number} logEventIdx
-     * @param {Number} initTimestamp
+     * @param {Number} initialTimestamp
      * @param {Number} pageSize
      */
-    constructor (fileInfo, prettify, logEventIdx, initTimestamp, pageSize) {
-        this._logFile = new FileManager(fileInfo, prettify,
-            logEventIdx, initTimestamp, pageSize,
-            this._loadingMessageCallback, this._updateStateCallback,
-            this._updateLogsCallback, this._updateFileInfoCallback);
+    constructor (fileInfo, prettify, logEventIdx, initialTimestamp, pageSize) {
+        this._logFile = new FileManager(fileInfo, prettify, logEventIdx, initialTimestamp, pageSize,
+            this._loadingMessageCallback, this._updateStateCallback, this._updateLogsCallback, 
+            this._updateFileInfoCallback);
         this._logFile.decompressAndLoadFile();
     }
 

--- a/src/Viewer/services/clpWorker.js
+++ b/src/Viewer/services/clpWorker.js
@@ -22,8 +22,8 @@ onmessage = function (e) {
                 const prettify = e.data.prettify;
                 const logEventIdx = e.data.logEventIdx;
                 const pageSize = e.data.pageSize;
-                const initialTimestamp = e.data.initialTimestamp
-                handler = new ActionHandler(fileInfo, prettify, logEventIdx, initialTimestamp, 
+                const initialTimestamp = e.data.initialTimestamp;
+                handler = new ActionHandler(fileInfo, prettify, logEventIdx, initialTimestamp,
                     pageSize);
             } catch (e) {
                 sendError(e);

--- a/src/Viewer/services/clpWorker.js
+++ b/src/Viewer/services/clpWorker.js
@@ -22,9 +22,9 @@ onmessage = function (e) {
                 const prettify = e.data.prettify;
                 const logEventIdx = e.data.logEventIdx;
                 const pageSize = e.data.pageSize;
-                const initTimestamp = e.data.initTimestamp
-                handler = new ActionHandler(fileInfo, prettify, logEventIdx,
-                    initTimestamp, pageSize);
+                const initialTimestamp = e.data.initialTimestamp
+                handler = new ActionHandler(fileInfo, prettify, logEventIdx, initialTimestamp, 
+                    pageSize);
             } catch (e) {
                 sendError(e);
             }

--- a/src/Viewer/services/clpWorker.js
+++ b/src/Viewer/services/clpWorker.js
@@ -22,7 +22,9 @@ onmessage = function (e) {
                 const prettify = e.data.prettify;
                 const logEventIdx = e.data.logEventIdx;
                 const pageSize = e.data.pageSize;
-                handler = new ActionHandler(fileInfo, prettify, logEventIdx, pageSize);
+                const initTimestamp = e.data.initTimestamp
+                handler = new ActionHandler(fileInfo, prettify, logEventIdx,
+                    initTimestamp, pageSize);
             } catch (e) {
                 sendError(e);
             }

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -132,7 +132,7 @@ class FileManager {
             if (null !== this._initTimestamp) {
                 console.debug(`Timestamp: ${this._initTimestamp}`);
                 const targetIdx = this._findFirstLogEventWithTimestamp(this._initTimestamp);
-                if (targetIdx !== numberOfEvents) {
+                if (targetIdx !== null) {
                     // We find a valid index.
                     // Increment by 1 to build the logEventIdx.
                     this.state.logEventIdx = targetIdx + 1;
@@ -196,8 +196,7 @@ class FileManager {
      * Since all the log events are naturally sorted w.r.t. the timestamp,
      * we can use binary search.
      * Return the index of the log event.
-     * If the log event doesn't exist, the function should return the total
-     * number of events.
+     * If the log event doesn't exist, the function should return null
      */
     _findFirstLogEventWithTimestamp (refTimestamp) {
         const numberOfEvents = this._logEventOffsets.length;
@@ -219,7 +218,7 @@ class FileManager {
         }
 
         // Not found
-        return numberOfEvents;
+        return null;
     }
 
     /**

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -193,12 +193,10 @@ class FileManager {
     };
 
     /**
-     * Gets the logEventIdx with the timestamp as milliseconds since the UNIX
-     * epoch.
      * @param {number} timestamp The timestamp to search for as milliseconds
      * since the UNIX epoch.
-     * @return {number} logEventIdx whose timestamp is greater than or equal to
-     * the given timestamp
+     * @return {number} The logEventIdx for the log event whose timestamp is
+     * greater than or equal to the given timestamp
      */
     getLogEventIdxFromTimestamp (timestamp) {
         const numberOfEvents = this._logEventOffsets.length;

--- a/src/Viewer/services/utils.js
+++ b/src/Viewer/services/utils.js
@@ -82,13 +82,14 @@ function isNumeric (value) {
 }
 
 /**
- * Given a timestamp, find the first log event whose timestamp is greater or 
- * equal to the timestamp, using binary search. It is assumed the given list
- * is sorted with an increasing timestamp.
- * @param {number} timestamp
- * @param {Array} logEventMetadata An array to store metadata objects with the
- * timestamp stored as the key:
- * "timestamp": The event's timestamp as milliseconds since the UNIX epoch.
+ * Given a list of log events, finds the first log event whose timestamp is
+ * greater than or equal to the given timestamp, using binary search. The given
+ * list must be sorted in increasing timestamp order.
+ * @param {number} timestamp The timestamp to search for as milliseconds since
+ * the UNIX epoch.
+ * @param {Object[]} logEventMetadata An array containing log event metadata
+ * objects, where the "timestamp" key in each object is the event's timestamp as
+ * milliseconds since the UNIX epoch.
  * @return {number|null} Index of the log event if found, or null otherwise
 */
 function binarySearchWithTimestamp (timestamp, logEventMetadata) {
@@ -102,7 +103,7 @@ function binarySearchWithTimestamp (timestamp, logEventMetadata) {
     if (length === 0) {
         return null;
     }
-    if (logEventMetadata[low].timestamp >= timestamp) {
+    if (timestamp <= logEventMetadata[low].timestamp) {
         return low;
     }
     if (logEventMetadata[high].timestamp < timestamp) {

--- a/src/Viewer/services/utils.js
+++ b/src/Viewer/services/utils.js
@@ -81,4 +81,52 @@ function isNumeric (value) {
     }
 }
 
-export {isNumeric, modifyFileMetadata, modifyPage};
+/**
+ * Given a timestamp, find the first log event whose timestamp is greater or 
+ * equal to the timestamp, using binary search. It is assumed the given list
+ * is sorted with an increasing timestamp.
+ * @param {number} timestamp
+ * @param {Array} logEventMetadata An array to store metadata objects with the
+ * timestamp stored as the key:
+ * "timestamp": The event's timestamp as milliseconds since the UNIX epoch.
+ * @return {number|null} Index of the log event if found, or null otherwise
+*/
+function binarySearchWithTimestamp (timestamp, logEventMetadata) {
+    const length = logEventMetadata.length;
+
+    let low = 0;
+    let high = length - 1;
+    let mid;
+
+    // Early exit
+    if (length === 0) {
+        return null;
+    }
+    if (logEventMetadata[low].timestamp >= timestamp) {
+        return low;
+    }
+    if (logEventMetadata[high].timestamp < timestamp) {
+        return null;
+    }
+
+    // Notice that the given timestamp might not show up in the events
+    // Suppose we have a list of timestamp: [2, 4, 4, 5, 6, 7],
+    // if timestamp = 3 is given, we should return the index of the first "4"
+    while (low <= high) {
+        mid = Math.floor((low + high) / 2);
+        if (logEventMetadata[mid].timestamp >= timestamp) {
+            if (logEventMetadata[mid - 1].timestamp < timestamp) {
+                return mid;
+            } else {
+                high = mid - 1;
+            }
+        } else {
+            low = mid + 1;
+        }
+    }
+
+    // Not found
+    return null;
+}
+
+export {binarySearchWithTimestamp, isNumeric, modifyFileMetadata, modifyPage};

--- a/src/Viewer/services/utils.test.js
+++ b/src/Viewer/services/utils.test.js
@@ -1,14 +1,13 @@
 import {binarySearchWithTimestamp} from "./utils";
 
-// This file tests the helper functions inside utils.
-
 /**
- * Using timestampArray as a reference, create an array named logEvents which
- * every single element in this array has a key named "timestamp".
+ * Using timestampArray as a reference, fill logEvents so that each element is
+ * an object with the key "timestamp" and the value of the corresponding
+ * timestampArray element.
  * @param {Array} logEvents
  * @param {Array} timestampArray Array of integers
  */
-function _loadLogEvents(logEvents, timestampArray) {
+function _loadLogEvents (logEvents, timestampArray) {
     logEvents.length = 0;
     for (let i = 0; i < timestampArray.length; ++i) {
         logEvents.push({"timestamp": timestampArray[i]});
@@ -16,10 +15,10 @@ function _loadLogEvents(logEvents, timestampArray) {
 }
 
 test("binarySearchWithTimestamp", () => {
-    let logEvents = [];
+    const logEvents = [];
     let timestampArray = [];
     let retval;
-    
+
     // Test if the logEvent array is empty
     retval = binarySearchWithTimestamp(0, logEvents);
     expect(retval).toBe(null);
@@ -35,7 +34,7 @@ test("binarySearchWithTimestamp", () => {
     expect(retval).toBe(null);
 
     // Test when the logEvent array has multiple elements but no duplicates
-    timestampArray = [3, 7, 9, 11, 14, 17, 20, 23, 31]
+    timestampArray = [3, 7, 9, 11, 14, 17, 20, 23, 31];
     _loadLogEvents(logEvents, timestampArray);
     retval = binarySearchWithTimestamp(1, logEvents);
     expect(retval).toBe(0);
@@ -53,7 +52,7 @@ test("binarySearchWithTimestamp", () => {
     expect(retval).toBe(null);
 
     // Test when the logEvent array has multiple elements and duplicates
-    timestampArray = [3, 7, 9, 11, 11, 11, 14, 17, 31, 31, 31, 39, 39, 40, 41, 41]
+    timestampArray = [3, 7, 9, 11, 11, 11, 14, 17, 31, 31, 31, 39, 39, 40, 41, 41];
     _loadLogEvents(logEvents, timestampArray);
     retval = binarySearchWithTimestamp(1, logEvents);
     expect(retval).toBe(0);

--- a/src/Viewer/services/utils.test.js
+++ b/src/Viewer/services/utils.test.js
@@ -1,0 +1,82 @@
+import {binarySearchWithTimestamp} from "./utils";
+
+// This file tests the helper functions inside utils.
+
+/**
+ * Using timestampArray as a reference, create an array named logEvents which
+ * every single element in this array has a key named "timestamp".
+ * @param {Array} logEvents
+ * @param {Array} timestampArray Array of integers
+ */
+function _loadLogEvents(logEvents, timestampArray) {
+    logEvents.length = 0;
+    for (let i = 0; i < timestampArray.length; ++i) {
+        logEvents.push({"timestamp": timestampArray[i]});
+    }
+}
+
+test("binarySearchWithTimestamp", () => {
+    let logEvents = [];
+    let timestampArray = [];
+    let retval;
+    
+    // Test if the logEvent array is empty
+    retval = binarySearchWithTimestamp(0, logEvents);
+    expect(retval).toBe(null);
+
+    // Test when the logEvent array only has one element
+    timestampArray = [1];
+    _loadLogEvents(logEvents, timestampArray);
+    retval = binarySearchWithTimestamp(0, logEvents);
+    expect(retval).toBe(0);
+    retval = binarySearchWithTimestamp(1, logEvents);
+    expect(retval).toBe(0);
+    retval = binarySearchWithTimestamp(1000, logEvents);
+    expect(retval).toBe(null);
+
+    // Test when the logEvent array has multiple elements but no duplicates
+    timestampArray = [3, 7, 9, 11, 14, 17, 20, 23, 31]
+    _loadLogEvents(logEvents, timestampArray);
+    retval = binarySearchWithTimestamp(1, logEvents);
+    expect(retval).toBe(0);
+    retval = binarySearchWithTimestamp(10, logEvents);
+    expect(retval).toBe(3);
+    retval = binarySearchWithTimestamp(11, logEvents);
+    expect(retval).toBe(3);
+    retval = binarySearchWithTimestamp(19, logEvents);
+    expect(retval).toBe(6);
+    retval = binarySearchWithTimestamp(31, logEvents);
+    expect(retval).toBe(8);
+    retval = binarySearchWithTimestamp(32, logEvents);
+    expect(retval).toBe(null);
+    retval = binarySearchWithTimestamp(1000, logEvents);
+    expect(retval).toBe(null);
+
+    // Test when the logEvent array has multiple elements and duplicates
+    timestampArray = [3, 7, 9, 11, 11, 11, 14, 17, 31, 31, 31, 39, 39, 40, 41, 41]
+    _loadLogEvents(logEvents, timestampArray);
+    retval = binarySearchWithTimestamp(1, logEvents);
+    expect(retval).toBe(0);
+    retval = binarySearchWithTimestamp(10, logEvents);
+    expect(retval).toBe(3);
+    retval = binarySearchWithTimestamp(11, logEvents);
+    expect(retval).toBe(3);
+    retval = binarySearchWithTimestamp(12, logEvents);
+    expect(retval).toBe(6);
+    retval = binarySearchWithTimestamp(30, logEvents);
+    expect(retval).toBe(8);
+    retval = binarySearchWithTimestamp(31, logEvents);
+    expect(retval).toBe(8);
+    retval = binarySearchWithTimestamp(32, logEvents);
+    expect(retval).toBe(11);
+    retval = binarySearchWithTimestamp(39, logEvents);
+    expect(retval).toBe(11);
+    retval = binarySearchWithTimestamp(40, logEvents);
+    expect(retval).toBe(13);
+    retval = binarySearchWithTimestamp(41, logEvents);
+    expect(retval).toBe(14);
+    retval = binarySearchWithTimestamp(42, logEvents);
+    expect(retval).toBe(null);
+    retval = binarySearchWithTimestamp(1000, logEvents);
+    expect(retval).toBe(null);
+});


### PR DESCRIPTION
# References
None.

# Description
This pull request lets users specify a timestamp (UNIX time in ms) in the URL search parameter. When the log file gets loaded, the logEventIdx will be set to the first log event whose timestamp is greater or equal to the specified timestamp.
An example URL: http://10.1.0.20:3010/?filePath=test.clp.zst&timestamp=1681425004750#logEventIdx=3000


# Validation performed

- Add new unit tests for general timestamp binary search.

- Manually validate behaviors of the following:

1. if the given timestamp is smaller than all the log events, logEventIdx will be set to 1.
2. if the timestamp exceeds all the events, logEventIdx will be set to the last event.
3. if the given timestamp is in the range of the loaded log file, it will be set to the first log event with a greater/equal timestamp.
4. if both timestamp (search para) and logEventIdx (hash para) are given in the URL, the given logEventIdx will be ignored.

