### PR TITLE
Add missing package monaco-editor@0.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "crypto-browserify": "^3.12.0",
     "css-unicode-loader": "^1.0.3",
     "html-webpack-plugin": "^5.5.0",
+    "monaco-editor": "^0.34.1",
     "monaco-editor-webpack-plugin": "^7.0.1",
     "path": "^0.12.7",
     "process": "^0.11.10",


### PR DESCRIPTION
# References
None.

# Environment
npm version: 6.14.18

# Description
Add a missing package to package.json so that `npm start` can be directly run after `npm i`

`npm i` outputs the following result:

```
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@^2.3.2 (node_modules/jest-haste-map/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN monaco-editor-webpack-plugin@7.0.1 requires a peer of monaco-editor@>= 0.31.0 but none is installed. You must install peer dependencies yourself.
npm WARN @monaco-editor/react@4.5.1 requires a peer of monaco-editor@>= 0.25.0 < 1 but none is installed. You must install peer dependencies yourself.
npm WARN react-monaco-editor@0.50.1 requires a peer of monaco-editor@^0.34.0 but none is installed. You must install peer dependencies yourself.
npm WARN @monaco-editor/loader@1.3.3 requires a peer of monaco-editor@>= 0.21.0 < 1 but none is installed. You must install peer dependencies yourself.

added 1107 packages from 561 contributors and audited 1110 packages in 38.67s

156 packages are looking for funding
  run `npm fund` for details

found 15 moderate severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details
```

# Validation performed
Tested on a fresh new repo.

