### PR TITLE
Update the IR format protocol version to 0.0.1

### DIFF
--- a/src/Viewer/services/decoder/DataInputStream.js
+++ b/src/Viewer/services/decoder/DataInputStream.js
@@ -142,6 +142,21 @@ class DataInputStream {
         this._byteIx += 4;
         return val;
     }
+
+    /**
+     * Reads a signed long int (64 bit)
+     * @return {BigInt} The read signed long int
+     */
+    readSignedLong(){
+        const requiredLen = this._byteIx + 8;
+        if (this._dataView.byteLength < requiredLen) {
+            this._byteIx = this._dataView.byteLength;
+            throw new DataInputStreamEOFError(this._dataView.byteLength, requiredLen);
+        }
+        const val = this._dataView.getBigInt64(this._byteIx, false);
+        this._byteIx += 8;
+        return val;
+    }
 }
 
 export {DataInputStream, DataInputStreamEOFError};

--- a/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
+++ b/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
@@ -48,7 +48,7 @@ class FourByteClpIrStreamProtocolDecoder {
         if (false === versionRegex.test(version)) {
             throw new Error(`Invalid Protocol Version: ${version}`);
         }
-        if (PROTOCOL.METADATA.VERSION_VALUE < versionRegex) {
+        if (PROTOCOL.METADATA.VERSION_VALUE < version) {
             throw new Error(`Input protocol version is too new: ${version}`);
         }
         const currentBuildProtocolMajorVersion = PROTOCOL.METADATA.VERSION_VALUE.split(".")[0];

--- a/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
+++ b/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
@@ -134,7 +134,7 @@ class FourByteClpIrStreamProtocolDecoder {
             case PROTOCOL.PAYLOAD.TIMESTAMP_DELTA_SIGNED_INT:
                 timestampDelta = dataInputStream.readInt();
                 break;
-            case PROTOCOL.PAYLOAD.TIMESTAMP_DELTA_SINGED_LONG:
+            case PROTOCOL.PAYLOAD.TIMESTAMP_DELTA_SIGNED_LONG:
                 timestampDelta = dataInputStream.readSignedLong();
                 break;
             case PROTOCOL.PAYLOAD.TIMESTAMP_NULL:

--- a/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
+++ b/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
@@ -1,4 +1,5 @@
 import PROTOCOL from "./PROTOCOL";
+import {getMajorVersion} from "./utils";
 
 class FourByteClpIrStreamProtocolDecoder {
     constructor (dataInputStream, tokenDecoder) {
@@ -42,18 +43,19 @@ class FourByteClpIrStreamProtocolDecoder {
 
     validateProtocolVersion (version) {
         if ("v0.0.0" === version) {
+            // This version is hardcoded to support the oldest IR protocol
+            // version. When this version is no longer supported, this branch
+            // should be removed.
             return;
         }
-        const versionRegex = new RegExp(PROTOCOL.METADATA.VERSION_REGEX);
+        const versionRegex = PROTOCOL.METADATA.VERSION_REGEX;
         if (false === versionRegex.test(version)) {
             throw new Error(`Invalid Protocol Version: ${version}`);
         }
         if (PROTOCOL.METADATA.VERSION_VALUE < version) {
             throw new Error(`Input protocol version is too new: ${version}`);
         }
-        const currentBuildProtocolMajorVersion = PROTOCOL.METADATA.VERSION_VALUE.split(".")[0];
-        const inputProtocolMajorVersion = version.split(".")[0];
-        if (currentBuildProtocolMajorVersion > inputProtocolMajorVersion) {
+        if (getMajorVersion(PROTOCOL.METADATA.VERSION_VALUE) > getMajorVersion(version)) {
             throw new Error(`Input protocol version is too old: ${version}`);
         }
     }

--- a/src/Viewer/services/decoder/PROTOCOL.js
+++ b/src/Viewer/services/decoder/PROTOCOL.js
@@ -2,7 +2,13 @@ const PROTOCOL = {
     FOUR_BYTE_ENCODING_MAGIC_NUMBER: [0xFD, 0x2F, 0xB5, 0x29],
     METADATA: {
         VERSION_KEY: "VERSION",
-        VERSION_VALUE: "v0.0.0",
+        VERSION_VALUE: "0.0.1",
+        // The following regex can be used to validate a Semantic Versioning string.
+        // The source of the regex can be found here: https://semver.org/
+        VERSION_REGEX: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)" +
+                       "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)" +
+                       "(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?" +
+                       "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
         REFERENCE_TIMESTAMP_KEY: "REFERENCE_TIMESTAMP",
         TIMESTAMP_PATTERN_KEY: "TIMESTAMP_PATTERN",
         TZ_ID_KEY: "TZ_ID",
@@ -27,6 +33,7 @@ const PROTOCOL = {
         TIMESTAMP_DELTA_SIGNED_BYTE: 0x31,
         TIMESTAMP_DELTA_SIGNED_SHORT: 0x32,
         TIMESTAMP_DELTA_SIGNED_INT: 0x33,
+        TIMESTAMP_DELTA_SINGED_LONG: 0x34,
         TIMESTAMP_NULL: 0x3F,
         // NOTE: JavaScript only supports 53-bit numbers safely, so we have to
         //       use BigInt for 64-bit numbers.

--- a/src/Viewer/services/decoder/PROTOCOL.js
+++ b/src/Viewer/services/decoder/PROTOCOL.js
@@ -33,7 +33,7 @@ const PROTOCOL = {
         TIMESTAMP_DELTA_SIGNED_BYTE: 0x31,
         TIMESTAMP_DELTA_SIGNED_SHORT: 0x32,
         TIMESTAMP_DELTA_SIGNED_INT: 0x33,
-        TIMESTAMP_DELTA_SINGED_LONG: 0x34,
+        TIMESTAMP_DELTA_SIGNED_LONG: 0x34,
         TIMESTAMP_NULL: 0x3F,
         // NOTE: JavaScript only supports 53-bit numbers safely, so we have to
         //       use BigInt for 64-bit numbers.

--- a/src/Viewer/services/decoder/PROTOCOL.js
+++ b/src/Viewer/services/decoder/PROTOCOL.js
@@ -3,12 +3,12 @@ const PROTOCOL = {
     METADATA: {
         VERSION_KEY: "VERSION",
         VERSION_VALUE: "0.0.1",
-        // The following regex can be used to validate a Semantic Versioning string.
-        // The source of the regex can be found here: https://semver.org/
-        VERSION_REGEX: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)" +
-                       "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)" +
-                       "(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?" +
-                       "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+        // The following regex can be used to validate a Semantic Versioning
+        // string. The source of the regex can be found here: https://semver.org
+        VERSION_REGEX: new RegExp("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"
+            + "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+            + "(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+            + "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"),
         REFERENCE_TIMESTAMP_KEY: "REFERENCE_TIMESTAMP",
         TIMESTAMP_PATTERN_KEY: "TIMESTAMP_PATTERN",
         TZ_ID_KEY: "TZ_ID",

--- a/src/Viewer/services/decoder/utils.js
+++ b/src/Viewer/services/decoder/utils.js
@@ -1,3 +1,11 @@
+/**
+ * @param {String} versionStr A complete semantic version number
+ * @return {String} The major version number
+ */
+function getMajorVersion (versionStr) {
+    return versionStr.split(".", 1)[0];
+}
+
 function javaIntegerDivide (top, bottom) {
     const integerQuotient = Math.trunc(top / bottom);
     // In Java -5 / 10 = 0 whereas in JavaScript, Math.trunc(-5 / 10) = -0, so
@@ -107,5 +115,5 @@ function isNumeric (value) {
     return (typeof value === "number");
 }
 
-export {countByteOccurrencesInUtf8Uint8Array, formatSizeInBytes,
-    isBoolean, isNumeric, javaIntegerDivide, uint8ArrayContains};
+export {countByteOccurrencesInUtf8Uint8Array, formatSizeInBytes, getMajorVersion, isBoolean,
+    isNumeric, javaIntegerDivide, uint8ArrayContains};


### PR DESCRIPTION
# Description
This PR updates the IR version to 0.0.1. It is porting changes from CLP OSS PR: https://github.com/y-scope/clp/pull/166
It supports decoding 64bit int encoded timestamp delta, and adds a method to validate the protocol version.

# Validation performed
1. Validates the version check doesn't break `v0.0.0` version.
2. Validates the latest version IR can be properly decoded.
3. Validates IR stream containing a 64-bit int timestamp delta can be properly decoded.