### PR TITLE
Revert to default pageSize after OOM happens

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import config from "./config.json";
 import {DropFile} from "./DropFile/DropFile";
 import {THEME_STATES} from "./ThemeContext/THEME_STATES";
 import {ThemeContext} from "./ThemeContext/ThemeContext";
+import LOCALSTORAGE_KEYS from "./Viewer/services/LOCALSTORAGE_KEYS";
 import VerbatimURLParams from "./Viewer/services/VerbatimURLParams";
 import {Viewer} from "./Viewer/Viewer";
 
@@ -32,13 +33,13 @@ export function App () {
 
     useEffect(() => {
         console.debug("Version:", config.version);
-        const lsTheme = localStorage.getItem("ui-theme");
+        const lsTheme = localStorage.getItem(LOCALSTORAGE_KEYS.UI_THEME);
         switchTheme(THEME_STATES.LIGHT === lsTheme ?THEME_STATES.LIGHT :THEME_STATES.DARK);
         init();
     }, []);
 
     const switchTheme = (theme) => {
-        localStorage.setItem("ui-theme", theme);
+        localStorage.setItem(LOCALSTORAGE_KEYS.UI_THEME, theme);
         document.getElementById("app").setAttribute("data-theme", theme);
         setTheme(theme);
     };

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import config from "./config.json";
 import {DropFile} from "./DropFile/DropFile";
 import {THEME_STATES} from "./ThemeContext/THEME_STATES";
 import {ThemeContext} from "./ThemeContext/ThemeContext";
-import LOCALSTORAGE_KEYS from "./Viewer/services/LOCALSTORAGE_KEYS";
+import LOCAL_STORAGE_KEYS from "./Viewer/services/LOCAL_STORAGE_KEYS";
 import VerbatimURLParams from "./Viewer/services/VerbatimURLParams";
 import {Viewer} from "./Viewer/Viewer";
 
@@ -33,13 +33,13 @@ export function App () {
 
     useEffect(() => {
         console.debug("Version:", config.version);
-        const lsTheme = localStorage.getItem(LOCALSTORAGE_KEYS.UI_THEME);
+        const lsTheme = localStorage.getItem(LOCAL_STORAGE_KEYS.UI_THEME);
         switchTheme(THEME_STATES.LIGHT === lsTheme ?THEME_STATES.LIGHT :THEME_STATES.DARK);
         init();
     }, []);
 
     const switchTheme = (theme) => {
-        localStorage.setItem(LOCALSTORAGE_KEYS.UI_THEME, theme);
+        localStorage.setItem(LOCAL_STORAGE_KEYS.UI_THEME, theme);
         document.getElementById("app").setAttribute("data-theme", theme);
         setTheme(theme);
     };

--- a/src/ThemeContext/README.md
+++ b/src/ThemeContext/README.md
@@ -28,7 +28,7 @@ const App = () => {
     const [appMode, setAppMode] = useState();
 
     const switchTheme = (theme) => {
-        localStorage.setItem("ui-theme", theme);
+        localStorage.setItem(LOCALSTORAGE_KEYS.UI_THEME, theme);
         document.getElementById("app").setAttribute("data-theme", theme);
         setTheme(theme);
     };
@@ -40,7 +40,7 @@ const App = () => {
     
     useEffect(() => {
         console.debug("Version:", config.version);
-        const lsTheme = localStorage.getItem("ui-theme");
+        const lsTheme = localStorage.getItem(LOCALSTORAGE_KEYS.UI_THEME);
         switchTheme(lsTheme === THEME_STATES.LIGHT?THEME_STATES.LIGHT:THEME_STATES.DARK);
         setAppMode(APP_STATE.FILE_PROMPT);
     }, []);

--- a/src/ThemeContext/README.md
+++ b/src/ThemeContext/README.md
@@ -28,7 +28,7 @@ const App = () => {
     const [appMode, setAppMode] = useState();
 
     const switchTheme = (theme) => {
-        localStorage.setItem(LOCALSTORAGE_KEYS.UI_THEME, theme);
+        localStorage.setItem(LOCAL_STORAGE_KEYS.UI_THEME, theme);
         document.getElementById("app").setAttribute("data-theme", theme);
         setTheme(theme);
     };
@@ -40,7 +40,7 @@ const App = () => {
     
     useEffect(() => {
         console.debug("Version:", config.version);
-        const lsTheme = localStorage.getItem(LOCALSTORAGE_KEYS.UI_THEME);
+        const lsTheme = localStorage.getItem(LOCAL_STORAGE_KEYS.UI_THEME);
         switchTheme(lsTheme === THEME_STATES.LIGHT?THEME_STATES.LIGHT:THEME_STATES.DARK);
         setAppMode(APP_STATE.FILE_PROMPT);
     }, []);

--- a/src/Viewer/README.md
+++ b/src/Viewer/README.md
@@ -43,13 +43,13 @@ const App = () => {
 
     useEffect(() => {
         console.debug("Version:", config.version);
-        const lsTheme = localStorage.getItem("ui-theme");
+        const lsTheme = localStorage.getItem(LOCALSTORAGE_KEYS.UI_THEME);
         switchTheme(THEME_STATES.LIGHT === lsTheme ?THEME_STATES.LIGHT :THEME_STATES.DARK);
         init();
     }, []);
 
     const switchTheme = (theme) => {
-        localStorage.setItem("ui-theme", theme);
+        localStorage.setItem(LOCALSTORAGE_KEYS.UI_THEME, theme);
         document.getElementById("app").setAttribute("data-theme", theme);
         setTheme(theme);
     };

--- a/src/Viewer/README.md
+++ b/src/Viewer/README.md
@@ -43,13 +43,13 @@ const App = () => {
 
     useEffect(() => {
         console.debug("Version:", config.version);
-        const lsTheme = localStorage.getItem(LOCALSTORAGE_KEYS.UI_THEME);
+        const lsTheme = localStorage.getItem(LOCAL_STORAGE_KEYS.UI_THEME);
         switchTheme(THEME_STATES.LIGHT === lsTheme ?THEME_STATES.LIGHT :THEME_STATES.DARK);
         init();
     }, []);
 
     const switchTheme = (theme) => {
-        localStorage.setItem(LOCALSTORAGE_KEYS.UI_THEME, theme);
+        localStorage.setItem(LOCAL_STORAGE_KEYS.UI_THEME, theme);
         document.getElementById("app").setAttribute("data-theme", theme);
         setTheme(theme);
     };

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -231,6 +231,24 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber, timestamp}) {
         modifyFileMetadata(fileMetadata, logFileState.logEventIdx);
     }, [fileMetadata]);
 
+    /**
+     * Gets called BEFORE the Monaco Editor is mounted
+     */
+    const handleMonacoBeforeMount = () => {
+        // Disable the cached "pageSize" in case it causes a client OOM. If it
+        // doesn't, the saved value will be restored in handleMonacoOnMount().
+        localStorage.removeItem("pageSize");
+    };
+
+    /**
+     * Gets called AFTER the Monaco Editor is mounted
+     */
+    const handleMonacoMount = useCallback(() => {
+        // No OOM occurred, so restore the "pageSize" value that was cleared in
+        // handleEditorWillMount().
+        localStorage.setItem("pageSize", logFileState.pageSize.toString());
+    }, [logFileState]);
+
     // Fires when hash is changed in the window.
     window.onhashchange = () => {
         const urlHashParams = new VerbatimURLParams(window.location.hash, "#");
@@ -273,8 +291,10 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber, timestamp}) {
                         <MonacoInstance
                             logData={logData}
                             loadingLogs={loadingLogs}
-                            changeStateCallback={changeState}
-                            logFileState={logFileState}/>
+                            logFileState={logFileState}
+                            onChangeState={changeState}
+                            onBeforeMount={handleMonacoBeforeMount}
+                            onMount={handleMonacoMount}/>
                     </div>
 
                     <StatusBar

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -292,8 +292,8 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber, timestamp}) {
                             logData={logData}
                             loadingLogs={loadingLogs}
                             logFileState={logFileState}
-                            onChangeState={changeState}
-                            onBeforeMount={unsetCachedPageSize}
+                            onStateChange={changeState}
+                            beforeMount={unsetCachedPageSize}
                             onMount={restoreCachedPageSize}/>
                     </div>
 

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -11,6 +11,7 @@ import MonacoInstance from "./components/Monaco/MonacoInstance";
 import {StatusBar} from "./components/StatusBar/StatusBar";
 import CLP_WORKER_PROTOCOL from "./services/CLP_WORKER_PROTOCOL";
 import FourByteClpIrStreamReader from "./services/decoder/FourByteClpIrStreamReader";
+import LOCALSTORAGE_KEYS from "./services/LOCALSTORAGE_KEYS";
 import MessageLogger from "./services/MessageLogger";
 import STATE_CHANGE_TYPE from "./services/STATE_CHANGE_TYPE";
 import {isNumeric, modifyFileMetadata, modifyPage} from "./services/utils";
@@ -52,7 +53,7 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber, timestamp}) {
     const [statusMessageLogs, setStatusMessageLogs] = useState([]);
 
     // Log States
-    const lsPageSize = localStorage.getItem("pageSize");
+    const lsPageSize = localStorage.getItem(LOCALSTORAGE_KEYS.PAGE_SIZE);
     const [logFileState, setLogFileState] = useState({
         pageSize: lsPageSize ? Number(lsPageSize) : 10000,
         pages: null,

--- a/src/Viewer/components/MenuBar/MenuBar.js
+++ b/src/Viewer/components/MenuBar/MenuBar.js
@@ -7,6 +7,7 @@ import {ChevronDoubleLeft, ChevronDoubleRight, ChevronLeft, ChevronRight,
 
 import {THEME_STATES} from "../../../ThemeContext/THEME_STATES";
 import {ThemeContext} from "../../../ThemeContext/ThemeContext";
+import LOCALSTORAGE_KEYS from "../../services/LOCALSTORAGE_KEYS";
 import MODIFY_PAGE_ACTION from "../../services/MODIFY_PAGE_ACTION";
 import STATE_CHANGE_TYPE from "../../services/STATE_CHANGE_TYPE";
 import {EditableInput} from "./EditableInput/EditableInput";
@@ -109,7 +110,7 @@ export function MenuBar ({
         e.preventDefault();
         handleCloseSettings();
         changeStateCallback(STATE_CHANGE_TYPE.pageSize, {pageSize: eventsPerPage});
-        localStorage.setItem("pageSize", String(eventsPerPage));
+        localStorage.setItem(LOCALSTORAGE_KEYS.PAGE_SIZE, String(eventsPerPage));
     };
 
     const closeModal = () => {

--- a/src/Viewer/components/MenuBar/MenuBar.js
+++ b/src/Viewer/components/MenuBar/MenuBar.js
@@ -7,7 +7,7 @@ import {ChevronDoubleLeft, ChevronDoubleRight, ChevronLeft, ChevronRight,
 
 import {THEME_STATES} from "../../../ThemeContext/THEME_STATES";
 import {ThemeContext} from "../../../ThemeContext/ThemeContext";
-import LOCALSTORAGE_KEYS from "../../services/LOCALSTORAGE_KEYS";
+import LOCAL_STORAGE_KEYS from "../../services/LOCAL_STORAGE_KEYS";
 import MODIFY_PAGE_ACTION from "../../services/MODIFY_PAGE_ACTION";
 import STATE_CHANGE_TYPE from "../../services/STATE_CHANGE_TYPE";
 import {EditableInput} from "./EditableInput/EditableInput";
@@ -110,7 +110,7 @@ export function MenuBar ({
         e.preventDefault();
         handleCloseSettings();
         changeStateCallback(STATE_CHANGE_TYPE.pageSize, {pageSize: eventsPerPage});
-        localStorage.setItem(LOCALSTORAGE_KEYS.PAGE_SIZE, String(eventsPerPage));
+        localStorage.setItem(LOCAL_STORAGE_KEYS.PAGE_SIZE, String(eventsPerPage));
     };
 
     const closeModal = () => {

--- a/src/Viewer/components/Monaco/MonacoInstance.js
+++ b/src/Viewer/components/Monaco/MonacoInstance.js
@@ -71,9 +71,9 @@ MonacoInstance.propTypes = {
 
 /**
  * Callback that gets called AFTER the Monaco Editor is mounted
- * @callback MountCallBack
- * @param {object} monaco
+ * @callback MountCallback
  * @param {object} editor
+ * @param {object} monaco
  */
 
 /**
@@ -86,7 +86,7 @@ MonacoInstance.propTypes = {
  * @param {string} logData Decoded log data to display
  * @param {ChangeStateCallback} onChangeState
  * @param {BeforeMountCallback} onBeforeMount
- * @param {MountCallBack} onMount
+ * @param {MountCallback} onMount
  * @return {JSX.Element}
  * @constructor
  */

--- a/src/Viewer/components/Monaco/MonacoInstance.js
+++ b/src/Viewer/components/Monaco/MonacoInstance.js
@@ -90,6 +90,10 @@ function MonacoInstance ({logFileState, changeStateCallback, loadingLogs, logDat
      * @param {object} monaco
      */
     function handleEditorWillMount (monaco) {
+        // "pageSize" will be restored in handleEditorDidMount()
+        //  if loading Monaco with this limit does not cause client OOM
+        localStorage.removeItem("pageSize");
+
         monaco.languages.typescript.javascriptDefaults.setEagerModelSync(true);
         monaco.editor.defineTheme("customLogLanguageDark", themes.dark);
         monaco.editor.defineTheme("customLogLanguageLight", themes.light);
@@ -122,6 +126,12 @@ function MonacoInstance ({logFileState, changeStateCallback, loadingLogs, logDat
      * @param {object} monaco
      */
     const handleEditorDidMount =(editor, monaco) => {
+        // Restore "pageSize" cleared in handleEditorWillMount()
+        //  if no OOM happens
+        setTimeout(()=>{
+            localStorage.setItem("pageSize", logFileState.pageSize);
+        }, 0);
+
         monacoRef.current = monaco;
         editorRef.current = editor;
         editorRef.current.setValue(logData);

--- a/src/Viewer/components/Monaco/MonacoInstance.js
+++ b/src/Viewer/components/Monaco/MonacoInstance.js
@@ -51,14 +51,14 @@ MonacoInstance.propTypes = {
     logFileState: PropTypes.object,
     loadingLogs: PropTypes.bool,
     logData: PropTypes.string,
-    onChangeState: PropTypes.func,
-    onBeforeMount: PropTypes.func,
+    onStateChange: PropTypes.func,
+    beforeMount: PropTypes.func,
     onMount: PropTypes.func,
 };
 
 /**
  * Callback used to change the parent component's state
- * @callback ChangeStateCallback
+ * @callback StateChangeCallback
  * @param {string} type The type of state change ({@link STATE_CHANGE_TYPE})
  * @param {object} args Arguments used to update the state
  */
@@ -84,8 +84,8 @@ MonacoInstance.propTypes = {
  * @param {object} logFileState Current state of the log file
  * @param {boolean} loadingLogs Indicates if loading is in progress
  * @param {string} logData Decoded log data to display
- * @param {ChangeStateCallback} onChangeState
- * @param {BeforeMountCallback} onBeforeMount
+ * @param {StateChangeCallback} onStateChange
+ * @param {BeforeMountCallback} beforeMount
  * @param {MountCallback} onMount
  * @return {JSX.Element}
  * @constructor
@@ -94,8 +94,8 @@ function MonacoInstance ({
     logFileState,
     loadingLogs,
     logData,
-    onChangeState,
-    onBeforeMount,
+    onStateChange,
+    beforeMount,
     onMount,
 }) {
     const {theme} = useContext(ThemeContext);
@@ -114,7 +114,7 @@ function MonacoInstance ({
      * @param {object} monaco
      */
     function handleEditorWillMount (monaco) {
-        onBeforeMount(monaco);
+        beforeMount(monaco);
 
         monaco.languages.typescript.javascriptDefaults.setEagerModelSync(true);
         monaco.editor.defineTheme("customLogLanguageDark", themes.dark);
@@ -163,7 +163,7 @@ function MonacoInstance ({
                     clearTimeout(timeoutRef.current);
                 }
                 timeoutRef.current = setTimeout(() => {
-                    onChangeState(STATE_CHANGE_TYPE.lineNumber, {
+                    onStateChange(STATE_CHANGE_TYPE.lineNumber, {
                         lineNumber: e.position.lineNumber,
                         columnNumber: e.position.column,
                     });
@@ -185,7 +185,7 @@ function MonacoInstance ({
                     ],
                     run: () => {
                         if (!loadingLogs) {
-                            onChangeState(shortcut.action, shortcut.actionArgs);
+                            onStateChange(shortcut.action, shortcut.actionArgs);
                         }
                     },
                 });
@@ -198,7 +198,7 @@ function MonacoInstance ({
                 ],
                 run: () => {
                     if (!loadingLogs) {
-                        onChangeState( STATE_CHANGE_TYPE.lineNumber, {
+                        onStateChange( STATE_CHANGE_TYPE.lineNumber, {
                             lineNumber: 1,
                             columnNumber: 1,
                         });
@@ -213,7 +213,7 @@ function MonacoInstance ({
                 ],
                 run: (editor) => {
                     if (!loadingLogs) {
-                        onChangeState( STATE_CHANGE_TYPE.lineNumber, {
+                        onStateChange( STATE_CHANGE_TYPE.lineNumber, {
                             lineNumber: editor.getModel().getLineCount(),
                             columnNumber: 1,
                         });

--- a/src/Viewer/services/LOCALSTORAGE_KEYS.js
+++ b/src/Viewer/services/LOCALSTORAGE_KEYS.js
@@ -1,0 +1,6 @@
+const LOCALSTORAGE_KEYS = Object.freeze({
+    UI_THEME: "uiTheme",
+    PAGE_SIZE: "pageSize",
+});
+
+export default LOCALSTORAGE_KEYS;

--- a/src/Viewer/services/LOCALSTORAGE_KEYS.js
+++ b/src/Viewer/services/LOCALSTORAGE_KEYS.js
@@ -1,6 +1,0 @@
-const LOCALSTORAGE_KEYS = Object.freeze({
-    UI_THEME: "uiTheme",
-    PAGE_SIZE: "pageSize",
-});
-
-export default LOCALSTORAGE_KEYS;

--- a/src/Viewer/services/LOCAL_STORAGE_KEYS.js
+++ b/src/Viewer/services/LOCAL_STORAGE_KEYS.js
@@ -1,0 +1,6 @@
+const LOCAL_STORAGE_KEYS = Object.freeze({
+    UI_THEME: "uiTheme",
+    PAGE_SIZE: "pageSize",
+});
+
+export default LOCAL_STORAGE_KEYS;


### PR DESCRIPTION
# References
https://github.com/y-scope/yscope-log-viewer/issues/28: User requested reverting to a safer `pageSize` when browser client crashes with a big value. 

# Description
Revert to default `pageSize` after OOM happens by:
1. Clear the `pageSize` setting in `localStorage` before Monaco loads.
2. Restore the setting in `localStorage` after Monaco loads successfully. 

If Monaco cannot load successfully, the setting will not be restored. Next time the application starts (e.g. when user refreshes the browser page) we will use a default `pageSize` setting which is supposedly safe. 

# Validation performed
In Microsoft Edge Version 121.0.2277.4, with https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst
1. Clear all cookies and localStorage with debug server address `http://localhost:3010`.
2. Access `http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst`.
3. Set `pageSize` to `1000000` and observed all logs to be loaded in a single page. 
4. Refreshed the browser page. Observed the browser client crashed and the browser displayed an "Out of Memory" error message.
5. Refreshed the browser page. Observed the Monaco instance to be loaded successfully with default `pageSize` which is `10000`.
6. Set `pageSize` to `1000` and observed total page numbers to increase.
7. Refreshed the browser page. Observed total page numbers unchanged compared to previous step and the set `pageSize` is `1000` in the Settings modal. 