### PR TITLE
Add .gitattributes and set default eol=lf.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
# References
When `git` clones a repo, EOL characters in source files are automatically replaced with system default (e.g. `CR LF` on Windows, `LF` on Linux). However, the project's ESLint configuration is extended from Google (`"extends": [..., "google"]`), which contains ['linebreak-style': 'error'](https://github.com/google/eslint-config-google/blob/cc39cf57d36b071985a15ccc97594cf12f52ef41/index.js#L233) that mandates new line characters to be `LF`. When running ESLint with `--fix` option, the linter unnecessarily changed all line characters to `LF` even for the lines authors did not modify and caused confusions in IDE visualizations. 
# Description
1. Add `.gitattributes` and set default eol=lf for all text files.

# Validation performed
1. Clone the modified repo. 
2. Run `npm i` to install package dependencies including `eslint`. 
3. Run `npx eslint *` and observe no errors reported regarding rule `linebreak-style`. 
