### PR TITLE
TBD - Support determining file type from magic numbers; Refactor loading logics in FileManager.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/y-scope/yscope-log-viewer#readme",
   "dependencies": {
+    "axios": "^1.6.7",
     "@obsidize/tar-browserify": "4.0.0",
     "bootstrap": "^5.2.3",
     "buffer": "^6.0.3",

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ export function App () {
     };
 
     const [appMode, setAppMode] = useState(null);
-    const [fileInfo, setFileInfo] = useState(null);
+    const [fileSrc, setFileSrc] = useState(null);
     const [logEventIdx, setLogEventIdx] = useState(null);
     const [timestamp, setTimestamp] = useState(null);
     const [prettify, setPrettify] = useState(null);
@@ -63,11 +63,11 @@ export function App () {
 
         const filePath = urlSearchParams.get("filePath");
         if (null !== filePath) {
-            setFileInfo(filePath);
+            setFileSrc(filePath);
             setAppMode(APP_STATE.FILE_VIEW);
         } else {
             if (null !== config.defaultFileUrl) {
-                setFileInfo(config.defaultFileUrl);
+                setFileSrc(config.defaultFileUrl);
                 setAppMode(APP_STATE.FILE_VIEW);
             } else {
                 setAppMode(APP_STATE.FILE_PROMPT);
@@ -80,7 +80,7 @@ export function App () {
      * @param {File} file
      */
     const handleFileChange = (file) => {
-        setFileInfo(file);
+        setFileSrc(file);
         setAppMode(APP_STATE.FILE_VIEW);
     };
 
@@ -92,7 +92,7 @@ export function App () {
                         <Viewer logEventNumber={logEventIdx}
                             timestamp={timestamp}
                             prettifyLog={prettify}
-                            fileInfo={fileInfo}/>
+                            fileSrc={fileSrc}/>
                     }
                 </DropFile>
             </ThemeContext.Provider>

--- a/src/DropFile/README.md
+++ b/src/DropFile/README.md
@@ -19,16 +19,16 @@ import {DropFile} from "./DropFile/DropFile";
 import "bootstrap/dist/css/bootstrap.min.css";
 
 const App = () => {
-    const [fileInfo, setFileInfo] = useState(null);
+    const [fileSrc, setFileSrc] = useState(null);
 
     const handleFileChange = (file) => {
-        setFileInfo(file);
+        setFileSrc(file);
     };
 
     return (
         <div id="app">
             <DropFile handleFileDrop={handleFileChange}>
-                <CustomComponent fileInfo={fileInfo}>
+                <CustomComponent fileSrc={fileSrc}>
             </DropFile>
         </div>
     );

--- a/src/ThemeContext/README.md
+++ b/src/ThemeContext/README.md
@@ -23,7 +23,7 @@ const App = () => {
         FILE_VIEW: 1,
     };
 
-    const [fileInfo, setFileInfo] = useState(null);
+    const [fileSrc, setfileSrc] = useState(null);
     const [theme, setTheme] = useState(THEME_STATES.DARK);
     const [appMode, setAppMode] = useState();
 
@@ -34,7 +34,7 @@ const App = () => {
     };
 
     const handleFileChange = (file) => {
-        setFileInfo(file);
+        setfileSrc(file);
         setAppMode(APP_STATE.FILE_VIEW);
     };
     
@@ -52,7 +52,7 @@ const App = () => {
                     {appMode === APP_STATE.VIEWER &&
                         <Viewer logEventNumber={333}
                             prettifyLog={true}
-                            fileInfo={fileInfo}/>
+                            fileSrc={fileSrc}/>
                     }
                 </DropFile>
             </ThemeContext.Provider>

--- a/src/Viewer/README.md
+++ b/src/Viewer/README.md
@@ -36,7 +36,7 @@ const App = () => {
     };
 
     const [appMode, setAppMode] = useState(null);
-    const [fileInfo, setFileInfo] = useState(null);
+    const [fileSrc, setfileSrc] = useState(null);
     const [logEventIdx, setLogEventIdx] = useState(null);
     const [prettify, setPrettify] = useState(null);
     const [theme, setTheme] = useState(THEME_STATES.DARK);
@@ -74,11 +74,11 @@ const App = () => {
         const filePath = urlSearchParams.get("filePath");
         console.log(filePath);
         if (undefined !== filePath) {
-            setFileInfo(filePath);
+            setfileSrc(filePath);
             setAppMode(APP_STATE.FILE_VIEW);
         } else {
             if (null !== config.defaultFileUrl) {
-                setFileInfo(config.defaultFileUrl);
+                setfileSrc(config.defaultFileUrl);
                 setAppMode(APP_STATE.FILE_VIEW);
             } else {
                 setAppMode(APP_STATE.FILE_PROMPT);
@@ -91,7 +91,7 @@ const App = () => {
      * @param {File} file
      */
     const handleFileChange = (file) => {
-        setFileInfo(file);
+        setfileSrc(file);
         setAppMode(APP_STATE.FILE_VIEW);
     };
 
@@ -102,7 +102,7 @@ const App = () => {
                     {(APP_STATE.FILE_VIEW === appMode) &&
                         <Viewer logEventNumber={logEventIdx}
                             prettifyLog={prettify}
-                            fileInfo={fileInfo}/>
+                            fileSrc={fileSrc}/>
                     }
                 </DropFile>
             </ThemeContext.Provider>

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -20,7 +20,6 @@ import "./Viewer.scss";
 
 Viewer.propTypes = {
     fileSrc: oneOfType([PropTypes.object, PropTypes.string]),
-    filePath: PropTypes.string,
     prettifyLog: PropTypes.bool,
     logEventNumber: PropTypes.string,
     timestamp: PropTypes.string,
@@ -229,7 +228,7 @@ export function Viewer ({fileSrc, prettifyLog, logEventNumber, timestamp}) {
 
     useEffect(() => {
         if (null !== fileInfo) {
-            const searchParams = {filePath: fileInfo.filePath};
+            const searchParams = {filePath: fileInfo.path};
             const hashParams = {logEventIdx: logFileState.logEventIdx};
 
             const newUrl = getModifiedUrl(searchParams, hashParams);

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -28,12 +28,12 @@ Viewer.propTypes = {
 /**
  * Contains the menu, Monaco editor, and status bar. Viewer spawns its own
  * worker to manage the file and perform CLP operations.
- * @param {File|String} fileSrc File object to read or file path to load
+ * @param {File|string} fileSrc File object or file path to load.
  * @param {boolean} prettifyLog Whether to prettify the log file
  * @param {Number} logEventNumber The initial log event number
  * @param {Number} timestamp The initial timestamp to show. If this field is
  * valid, logEventNumber will be ignored.
- * @return {JSX.Element}
+ * @returns {JSX.Element}
  */
 export function Viewer ({fileSrc, prettifyLog, logEventNumber, timestamp}) {
     const {theme} = useContext(ThemeContext);
@@ -77,10 +77,10 @@ export function Viewer ({fileSrc, prettifyLog, logEventNumber, timestamp}) {
     }, []);
 
     /**
-     * Reload viewer on fileSrc change
-     * @param {File|string} fileSrc
+     * Reload viewer on `fileSrc` change
+     * @param {File|string} src
      */
-    const loadFile = (fileSrc) => {
+    const loadFile = (src) => {
         if (clpWorker.current) {
             clpWorker.current.terminate();
         }
@@ -91,12 +91,13 @@ export function Viewer ({fileSrc, prettifyLog, logEventNumber, timestamp}) {
         // Create new worker and pass args to worker to load file
         clpWorker.current = new Worker(new URL("./services/clpWorker.js", import.meta.url));
         clpWorker.current.onmessage = handleWorkerMessage;
+
         // If file was loaded using file dialog or drag/drop, reset logEventIdx
-        const logEvent = (typeof fileSrc === "string") ? logFileState.logEventIdx : null;
+        const logEvent = ("string" === typeof src) ? logFileState.logEventIdx : null;
         const initialTimestamp = isNumeric(timestamp) ? Number(timestamp) : null;
         clpWorker.current.postMessage({
             code: CLP_WORKER_PROTOCOL.LOAD_FILE,
-            fileSrc: fileSrc,
+            fileSrc: src,
             prettify: logFileState.prettify,
             logEventIdx: logEvent,
             initialTimestamp: initialTimestamp,

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -33,7 +33,7 @@ Viewer.propTypes = {
  * @param {Number} logEventNumber The initial log event number
  * @param {Number} timestamp The initial timestamp to show. If this field is
  * valid, logEventNumber will be ignored.
- * @returns {JSX.Element}
+ * @return {JSX.Element}
  */
 export function Viewer ({fileSrc, prettifyLog, logEventNumber, timestamp}) {
     const {theme} = useContext(ThemeContext);

--- a/src/Viewer/components/MenuBar/MenuBar.js
+++ b/src/Viewer/components/MenuBar/MenuBar.js
@@ -44,7 +44,7 @@ MenuBar.propTypes = {
  *                              loaded by worker.
  * @param {ChangeStateCallback} changeStateCallback
  * @param {LoadFileCallback} loadFileCallback
- * @returns {JSX.Element}
+ * @return {JSX.Element}
  */
 export function MenuBar ({
     logFileState, fileInfo, loadingLogs, changeStateCallback, loadFileCallback,

--- a/src/Viewer/components/MenuBar/MenuBar.js
+++ b/src/Viewer/components/MenuBar/MenuBar.js
@@ -16,7 +16,7 @@ import "./MenuBar.scss";
 
 MenuBar.propTypes = {
     logFileState: PropTypes.object,
-    fileMetaData: PropTypes.object,
+    fileInfo: PropTypes.object,
     loadingLogs: PropTypes.bool,
     changeStateCallback: PropTypes.func,
     loadFileCallback: PropTypes.func,
@@ -33,13 +33,13 @@ MenuBar.propTypes = {
  * This callback is used to load a new file.
  *
  * @callback LoadFileCallback
- * @param {File|String} fileInfo File object or file path to load.
+ * @param {File|String} fileSrc File object or file path to load.
  */
 
 /**
  * Menu bar used to navigate the log file.
  * @param {object} logFileState Current state of the log file
- * @param {object} fileMetaData Object containing file metadata
+ * @param {object} fileInfo Object containing file name & path
  * @param {boolean} loadingLogs Indicates if logs are being decoded and
  *                              loaded by worker.
  * @param {ChangeStateCallback} changeStateCallback
@@ -47,7 +47,7 @@ MenuBar.propTypes = {
  * @return {JSX.Element}
  */
 export function MenuBar ({
-    logFileState, fileMetaData, loadingLogs, changeStateCallback, loadFileCallback,
+    logFileState, fileInfo, loadingLogs, changeStateCallback, loadFileCallback,
 }) {
     const {theme, switchTheme} = useContext(ThemeContext);
 
@@ -176,9 +176,9 @@ export function MenuBar ({
                 <div style={{height: loadingBarHeight}} className="w-100" />
                 <div className="viewer-header-menu-container">
                     <div className="menu-left">
-                        <div className="menu-item" title={fileMetaData.name}>
+                        <div className="menu-item" title={fileInfo.name}>
                             <FileText className="mx-2"/>
-                            <span className="d-none d-lg-block">{fileMetaData.name}</span>
+                            <span className="d-none d-lg-block">{fileInfo.name}</span>
                         </div>
                     </div>
                     <div className="menu-right">

--- a/src/Viewer/components/MenuBar/MenuBar.js
+++ b/src/Viewer/components/MenuBar/MenuBar.js
@@ -33,7 +33,7 @@ MenuBar.propTypes = {
  * This callback is used to load a new file.
  *
  * @callback LoadFileCallback
- * @param {File|String} fileSrc File object or file path to load.
+ * @param {File|string} fileSrc File object or file path to load.
  */
 
 /**
@@ -44,7 +44,7 @@ MenuBar.propTypes = {
  *                              loaded by worker.
  * @param {ChangeStateCallback} changeStateCallback
  * @param {LoadFileCallback} loadFileCallback
- * @return {JSX.Element}
+ * @returns {JSX.Element}
  */
 export function MenuBar ({
     logFileState, fileInfo, loadingLogs, changeStateCallback, loadFileCallback,

--- a/src/Viewer/services/ActionHandler.js
+++ b/src/Viewer/services/ActionHandler.js
@@ -15,17 +15,25 @@ import {isBoolean, isNumeric} from "./decoder/utils";
 class ActionHandler {
     /**
      * Creates a new FileManager object and initiates the download.
-     * @param {String|File} fileInfo
+     * @param {String|File} fileSrc
      * @param {boolean} prettify
      * @param {Number} logEventIdx
      * @param {Number} initialTimestamp
      * @param {Number} pageSize
      */
-    constructor (fileInfo, prettify, logEventIdx, initialTimestamp, pageSize) {
-        this._logFile = new FileManager(fileInfo, prettify, logEventIdx, initialTimestamp, pageSize,
-            this._loadingMessageCallback, this._updateStateCallback, this._updateLogsCallback,
+    constructor (fileSrc, prettify, logEventIdx, initialTimestamp, pageSize) {
+        this._logFile = new FileManager(fileSrc, prettify, logEventIdx, initialTimestamp, pageSize,
+            this._loadingMessageCallback,
+            this._updateStateCallback,
+            this._updateLogsCallback,
             this._updateFileInfoCallback);
-        this._logFile.loadLogFile();
+
+        this._logFile.loadLogFile().then(()=> {
+            console.log(fileSrc, "File loaded successfully");
+        }).catch((e) => {
+            this._loadingMessageCallback(e, true);
+            console.error("Error processing log file:", e);
+        });
     }
 
     /**
@@ -192,12 +200,12 @@ class ActionHandler {
 
     /**
      * Send the file information.
-     * @param {string} fileState
+     * @param {string} fileInfo
      */
-    _updateFileInfoCallback = (fileState) => {
+    _updateFileInfoCallback = (fileInfo) => {
         postMessage({
             code: CLP_WORKER_PROTOCOL.UPDATE_FILE_INFO,
-            fileState: fileState,
+            fileInfo: fileInfo,
         });
     };
 }

--- a/src/Viewer/services/ActionHandler.js
+++ b/src/Viewer/services/ActionHandler.js
@@ -15,7 +15,7 @@ import {isBoolean, isNumeric} from "./decoder/utils";
 class ActionHandler {
     /**
      * Creates a new FileManager object and initiates the download.
-     * @param {String|File} fileSrc
+     * @param {File|string} fileSrc
      * @param {boolean} prettify
      * @param {Number} logEventIdx
      * @param {Number} initialTimestamp
@@ -28,12 +28,14 @@ class ActionHandler {
             this._updateLogsCallback,
             this._updateFileInfoCallback);
 
-        this._logFile.loadLogFile().then(()=> {
-            console.log(fileSrc, "File loaded successfully");
-        }).catch((e) => {
-            this._loadingMessageCallback(e, true);
-            console.error("Error processing log file:", e);
-        });
+        this._logFile.loadLogFile()
+            .then(() => {
+                console.log(fileSrc, "File loaded successfully");
+            })
+            .catch((e) => {
+                this._loadingMessageCallback(e, true);
+                console.error("Error processing log file:", e);
+            });
     }
 
     /**
@@ -200,7 +202,7 @@ class ActionHandler {
 
     /**
      * Send the file information.
-     * @param {string} fileInfo
+     * @param {object} fileInfo
      */
     _updateFileInfoCallback = (fileInfo) => {
         postMessage({

--- a/src/Viewer/services/GetFile.js
+++ b/src/Viewer/services/GetFile.js
@@ -1,9 +1,22 @@
+import axios from "axios";
+
 /**
- * Error class for HTTP requests
+ * Custom error class for representing HTTP request errors.
+ *
+ * @class HTTPRequestError
+ * @extends {Error}
  */
 class HTTPRequestError extends Error {
+    /**
+     * Constructs and initializes instance of HTTPRequestError
+     *
+     * @param {string} url of the HTTP request that resulted in an error
+     * @param {number} status code of the response
+     * @param {string} statusText of the response
+     */
     constructor (url, status, statusText) {
         super(`${url} returned ${status} ${statusText}`);
+
         this.name = "HTTPRequestError";
         this.url = url;
         this.status = status;
@@ -18,130 +31,91 @@ class HTTPRequestError extends Error {
  * @param {number} numBytesDownloaded Bytes downloaded
  * @param {number} fileSizeBytes Size of file in Bytes
  */
-
 /**
- * Creates a promise that downloads a file with the given URL or gets
- * the data from input file. The given callback is called whenever
- * the download makes progress.
- *
- * @param {string|object} fileInfo A File object or a file path to download
- * @param {ProgressCallback} progressCallback Callback to update progress
- * @return {Promise<Uint8Array>} A promise that resolves with the file's content
- */
-function readFile (fileInfo, progressCallback) {
-    return new Promise(async (resolve, reject) => {
-        if (fileInfo instanceof File) {
-            readFileInputPromise(fileInfo, progressCallback).then((data) => {
-                resolve({
-                    name: fileInfo.name,
-                    filePath: null,
-                    data: data,
-                });
-            }).catch((reason) => {
-                reject(reason);
-            });
-        } else if (typeof fileInfo == "string") {
-            const name = fileInfo.split("/").pop();
-            getFetchFilePromise(fileInfo, progressCallback).then((data) => {
-                resolve({
-                    name: name,
-                    filePath: fileInfo,
-                    data: data,
-                });
-            }).catch((reason) => {
-                reject(reason);
-            });
-        } else {
-            reject(new Error("Invalid file"));
-        }
-    });
-}
-
-/**
- * Creates a promise that downloads a file with the given URL. The given
- * callback is called whenever the download makes progress.
+ * Downloads and reads a file with a given URL.
  *
  * @param {string} fileUrl
  * @param {ProgressCallback} progressCallback Callback to update progress
- * @return {Promise<Uint8Array>} A promise that resolves with the file's content
+ * @return {Uint8Array} File content
  */
-function getFetchFilePromise (fileUrl, progressCallback) {
-    return new Promise(async (resolve, reject) => {
-        fetch(fileUrl, {cache: "no-cache"}).then(async (response) => {
-            if (false === response.ok) {
-                throw new HTTPRequestError(fileUrl, response.status, response.statusText);
-            }
-            const reader = response.body.getReader();
-            const totalBytes = +response.headers.get("Content-Length");
-
-            let receivedBytes = 0;
-            const chunks = [];
-            while (true) {
-                const {done, value} = await reader.read();
-                if (done) {
-                    break;
-                }
-                chunks.push(value);
-                receivedBytes += value.length;
-                progressCallback(receivedBytes, totalBytes);
-                console.debug(`Received ${receivedBytes}B of ${totalBytes}B`);
-            }
-
-            const concatenatedChunks = new Uint8Array(receivedBytes);
-            let pos = 0;
-            for (const chunk of chunks) {
-                concatenatedChunks.set(chunk, pos);
-                pos += chunk.length;
-            }
-            resolve(concatenatedChunks);
-        }).catch((reason) => {
-            reject(reason);
+const downloadAndReadFile = async (fileUrl, progressCallback) => {
+    try {
+        const {data} = await axios.get(fileUrl, {
+            responseType: "arraybuffer",
+            onDownloadProgress: (progressEvent) => {
+                progressCallback(progressEvent.loaded, progressEvent.total);
+            },
+            headers: {
+                "Cache-Control": "no-cache",
+                "Pragma": "no-cache",
+                "Expires": "0",
+            },
         });
-    });
-}
+
+        return new Uint8Array(data);
+    } catch (e) {
+        throw new HTTPRequestError(fileUrl, e.response.status, e.response.data);
+    }
+};
 
 /**
- * Get the size of a file.
- *
- * @param {string} url
- * @param {function} updateSizeCallback
- */
-function getFileSize (url, updateSizeCallback) {
-    fetch(url, {method: "HEAD"})
-        .then(function (response) {
-            if (response.ok) {
-                updateSizeCallback(parseInt(response.headers.get("Content-Length")));
-                return parseInt(response.headers.get("Content-Length"));
-            } else {
-                console.error(`Failed to get file size for ${url} -`,
-                    `${response.status} ${response.statusText}`);
-            }
-        })
-        .catch(function (reason) {
-            console.error(`Failed to get file size for ${url} - ${reason}`);
-        });
-}
-
-/**
- * Reads a file object using FileReader, resolves with the data from the file.
+ * Reads a File object using FileReader.
  *
  * @param {File} file File object to read data from.
  * @param {ProgressCallback} progressCallback Callback to update progress
- * @return {Promise<Uint8Array>} A promise that resolves with the file's content
+ * @return {Uint8Array} File content
  */
-function readFileInputPromise (file, progressCallback) {
-    return new Promise(async (resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = (event) => {
-            progressCallback(file.size, file.size);
-            resolve(new Uint8Array(event.target.result));
+const readFileObject = (file, progressCallback) => new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = (event) => {
+        progressCallback(file.size, file.size);
+        resolve(new Uint8Array(reader.result));
+    };
+    reader.onerror = () => {
+        reject(reader.error);
+    };
+
+    reader.readAsArrayBuffer(file);
+});
+
+/**
+ * Input File Information
+ *
+ * @typedef {Object} FileInfo
+ * @property {string} name File name
+ * @property {string|null} [filePath] File URL when the file is downloaded
+ * @property {Uint8Array} data File content
+ */
+/**
+ * Gets content from an input file. If given `fileSrc` is a string, treat it as
+ * a URL and download before getting data.
+ *
+ * @param {string|File} fileSrc A File object or a file URL to download
+ * @param {ProgressCallback} progressCallback Callback to update progress
+ * @return {FileInfo} Input File Information which contains the file content
+ */
+const readFile = async (fileSrc, progressCallback) => {
+    let fileInfo = null;
+
+    if (fileSrc instanceof File) {
+        const data = await readFileObject(fileSrc, progressCallback);
+        fileInfo = {
+            name: fileSrc.name,
+            filePath: null,
+            data: data,
         };
-        // TODO Revisit errors when trying to read the file.
-        reader.onerror = () => {
-            reject(reader.error);
+    } else if ("string" === typeof fileSrc) {
+        const name = fileSrc.split("/").pop();
+        const data = await downloadAndReadFile(fileSrc, progressCallback);
+        fileInfo = {
+            name: name,
+            filePath: fileSrc,
+            data: data,
         };
-        reader.readAsArrayBuffer(file);
-    });
-}
+    }
+
+    return fileInfo;
+};
 
 export {readFile};

--- a/src/Viewer/services/GetFile.js
+++ b/src/Viewer/services/GetFile.js
@@ -36,7 +36,7 @@ class HTTPRequestError extends Error {
  *
  * @param {string} fileUrl
  * @param {ProgressCallback} progressCallback Callback to update progress
- * @return {Uint8Array} File content
+ * @returns {Uint8Array} File content
  */
 const downloadAndReadFile = async (fileUrl, progressCallback) => {
     try {
@@ -48,7 +48,6 @@ const downloadAndReadFile = async (fileUrl, progressCallback) => {
             headers: {
                 "Cache-Control": "no-cache",
                 "Pragma": "no-cache",
-                "Expires": "0",
             },
         });
 
@@ -63,7 +62,7 @@ const downloadAndReadFile = async (fileUrl, progressCallback) => {
  *
  * @param {File} file File object to read data from.
  * @param {ProgressCallback} progressCallback Callback to update progress
- * @return {Uint8Array} File content
+ * @returns {Uint8Array} File content
  */
 const readFileObject = (file, progressCallback) => new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -80,20 +79,18 @@ const readFileObject = (file, progressCallback) => new Promise((resolve, reject)
 });
 
 /**
- * Input File Information
- *
  * @typedef {Object} FileInfo
  * @property {string} name File name
  * @property {string|null} [filePath] File URL when the file is downloaded
  * @property {Uint8Array} data File content
  */
 /**
- * Gets content from an input file. If given `fileSrc` is a string, treat it as
- * a URL and download before getting data.
+ * Gets content from an input file. If `fileSrc` is a string, treat it as a URL
+ * and download before getting data.
  *
- * @param {string|File} fileSrc A File object or a file URL to download
+ * @param {File|string} fileSrc A File object or a file URL to download
  * @param {ProgressCallback} progressCallback Callback to update progress
- * @return {FileInfo} Input File Information which contains the file content
+ * @returns {FileInfo} The file's content and metadata
  */
 const readFile = async (fileSrc, progressCallback) => {
     let fileInfo = null;

--- a/src/Viewer/services/GetFile.js
+++ b/src/Viewer/services/GetFile.js
@@ -36,7 +36,7 @@ class HTTPRequestError extends Error {
  *
  * @param {string} fileUrl
  * @param {ProgressCallback} progressCallback Callback to update progress
- * @returns {Uint8Array} File content
+ * @return {Uint8Array} File content
  */
 const downloadAndReadFile = async (fileUrl, progressCallback) => {
     try {
@@ -62,7 +62,7 @@ const downloadAndReadFile = async (fileUrl, progressCallback) => {
  *
  * @param {File} file File object to read data from.
  * @param {ProgressCallback} progressCallback Callback to update progress
- * @returns {Uint8Array} File content
+ * @return {Uint8Array} File content
  */
 const readFileObject = (file, progressCallback) => new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -90,7 +90,7 @@ const readFileObject = (file, progressCallback) => new Promise((resolve, reject)
  *
  * @param {File|string} fileSrc A File object or a file URL to download
  * @param {ProgressCallback} progressCallback Callback to update progress
- * @returns {FileInfo} The file's content and metadata
+ * @return {FileInfo} The file's content and metadata
  */
 const readFile = async (fileSrc, progressCallback) => {
     let fileInfo = null;

--- a/src/Viewer/services/GetFile.js
+++ b/src/Viewer/services/GetFile.js
@@ -54,7 +54,7 @@ const downloadAndReadFile = async (fileUrl, progressCallback) => {
 
         return new Uint8Array(data);
     } catch (e) {
-        throw new HTTPRequestError(fileUrl, e.response.status, e.response.data);
+        throw new HTTPRequestError(fileUrl, e.response.status, e.response.statusText);
     }
 };
 
@@ -102,15 +102,14 @@ const readFile = async (fileSrc, progressCallback) => {
         const data = await readFileObject(fileSrc, progressCallback);
         fileInfo = {
             name: fileSrc.name,
-            filePath: null,
+            path: null,
             data: data,
         };
     } else if ("string" === typeof fileSrc) {
-        const name = fileSrc.split("/").pop();
         const data = await downloadAndReadFile(fileSrc, progressCallback);
         fileInfo = {
-            name: name,
-            filePath: fileSrc,
+            name: new URL(fileSrc).pathname.split("/").pop(),
+            path: fileSrc,
             data: data,
         };
     }

--- a/src/Viewer/services/GetFile.js
+++ b/src/Viewer/services/GetFile.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 
+
 /**
  * Custom error class for representing HTTP request errors.
  *
@@ -36,7 +37,7 @@ class HTTPRequestError extends Error {
  *
  * @param {string} fileUrl
  * @param {ProgressCallback} progressCallback Callback to update progress
- * @return {Uint8Array} File content
+ * @return {Promise<Uint8Array>} File content
  */
 const downloadAndReadFile = async (fileUrl, progressCallback) => {
     try {
@@ -62,7 +63,7 @@ const downloadAndReadFile = async (fileUrl, progressCallback) => {
  *
  * @param {File} file File object to read data from.
  * @param {ProgressCallback} progressCallback Callback to update progress
- * @return {Uint8Array} File content
+ * @return {Promise<Uint8Array>} File content
  */
 const readFileObject = (file, progressCallback) => new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -90,7 +91,7 @@ const readFileObject = (file, progressCallback) => new Promise((resolve, reject)
  *
  * @param {File|string} fileSrc A File object or a file URL to download
  * @param {ProgressCallback} progressCallback Callback to update progress
- * @return {FileInfo} The file's content and metadata
+ * @return {Promise<FileInfo>} The file's content and metadata
  */
 const readFile = async (fileSrc, progressCallback) => {
     let fileInfo = null;

--- a/src/Viewer/services/clpWorker.js
+++ b/src/Viewer/services/clpWorker.js
@@ -18,12 +18,12 @@ onmessage = function (e) {
     switch (e.data.code) {
         case CLP_WORKER_PROTOCOL.LOAD_FILE:
             try {
-                const fileInfo = e.data.fileInfo;
+                const fileSrc = e.data.fileSrc;
                 const prettify = e.data.prettify;
                 const logEventIdx = e.data.logEventIdx;
                 const pageSize = e.data.pageSize;
                 const initialTimestamp = e.data.initialTimestamp;
-                handler = new ActionHandler(fileInfo, prettify, logEventIdx, initialTimestamp,
+                handler = new ActionHandler(fileSrc, prettify, logEventIdx, initialTimestamp,
                     pageSize);
             } catch (e) {
                 sendError(e);

--- a/src/Viewer/services/decoder/FILE_FORMATS.js
+++ b/src/Viewer/services/decoder/FILE_FORMATS.js
@@ -1,34 +1,39 @@
 const FILE_TYPES = Object.freeze({
-    NONE: "none",
+    UNKNOWN: "unknown",
+
     CLP_IR: "clp_ir",
-    ZST: "zst",
     GZ: "gz",
     TAR_GZ: "tar_gz",
     ZIP: "zip",
+    ZST: "zst",
 });
 
-const FILE_EXTENSION_MAPS = Object.freeze({
-    ".txt": FILE_TYPES.NONE,
+const FILE_EXTENSION_TO_TYPE = Object.freeze({
+    ".txt": FILE_TYPES.UNKNOWN,
+
     ".clp.zst": FILE_TYPES.CLP_IR,
-    ".zst": FILE_TYPES.ZST,
     ".gz": FILE_TYPES.GZ,
-    ".tar.gz": FILE_TYPES.TAR_GZ,
     ".gzip": FILE_TYPES.GZ,
+    ".tar.gz": FILE_TYPES.TAR_GZ,
     ".zip": FILE_TYPES.ZIP,
+    ".zst": FILE_TYPES.ZST,
 });
 
 const FILE_TYPE_FULL_NAMES = Object.freeze({
-    [FILE_TYPES.NONE]: "Plain Text",
-    [FILE_TYPES.CLP_IR]: "CLP IR Stream",
-    [FILE_TYPES.ZST]: "Zstandard",
-    [FILE_TYPES.TAR_GZ]: "Tarball Gzip",
+    [FILE_TYPES.UNKNOWN]: "Plain text",
+
+    [FILE_TYPES.CLP_IR]: "CLP IR stream",
     [FILE_TYPES.GZ]: "Gzip",
-    [FILE_TYPES.ZIP]: "PKZip",
+    [FILE_TYPES.TAR_GZ]: "Tarball Gzip",
+    [FILE_TYPES.ZIP]: "ZIP",
+    [FILE_TYPES.ZST]: "Zstandard",
 });
 
+/* eslint-disable no-magic-numbers, @stylistic/js/array-element-newline */
 const FILE_TYPE_MAGIC_NUMBERS = Object.freeze({
-    // NOTE: this magic number is checked AFTER Zstd decompression
-    [FILE_TYPES.CLP_IR]: [0xFD, 0x2F, 0xB5, 0x29],
+    // NOTE: A typical CLP IR stream is also compressed with Zstandard, so this
+    // magic number is checked *after* Zstd decompression.
+    [FILE_TYPES.CLP_IR]: [0xfd, 0x2f, 0xb5, 0x29],
 
     // https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1
     [FILE_TYPES.ZST]: [0x28, 0xb5, 0x2f, 0xfd],
@@ -48,17 +53,16 @@ const FILE_TYPE_MAGIC_NUMBERS = Object.freeze({
     // https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
     [FILE_TYPES.ZIP]: [0x50, 0x4b, 0x03, 0x04],
 });
+/* eslint-enable no-magic-numbers, @stylistic/js/array-element-newline */
 
-// For below file types, recheck content type after first decompression
-const FILE_TYPE_RECHECK_LIST = [
-    FILE_TYPES.ZST,
-];
+// The file types whose type needs to be rechecked after first decompression
+const FILE_TYPE_RECHECK_LIST = [FILE_TYPES.ZST];
 
 
 export {
-    FILE_TYPES,
-    FILE_EXTENSION_MAPS,
+    FILE_EXTENSION_TO_TYPE,
     FILE_TYPE_FULL_NAMES,
     FILE_TYPE_MAGIC_NUMBERS,
     FILE_TYPE_RECHECK_LIST,
+    FILE_TYPES,
 };

--- a/src/Viewer/services/decoder/FILE_FORMATS.js
+++ b/src/Viewer/services/decoder/FILE_FORMATS.js
@@ -1,0 +1,56 @@
+let enumFileTypes;
+export const FILE_TYPES = Object.freeze({
+    NONE: (enumFileTypes = 0),
+    CLP_IR: ++enumFileTypes,
+    ZST: ++enumFileTypes,
+    GZ: ++enumFileTypes,
+    TAR_GZ: ++enumFileTypes,
+    ZIP: ++enumFileTypes,
+});
+
+export const FILE_EXTENSION_MAPS = Object.freeze({
+    ".txt": FILE_TYPES.NONE,
+    ".clp.zst": FILE_TYPES.CLP_IR,
+    ".zst": FILE_TYPES.ZST,
+    ".gz": FILE_TYPES.GZ,
+    ".tar.gz": FILE_TYPES.TAR_GZ,
+    ".gzip": FILE_TYPES.GZ,
+    ".zip": FILE_TYPES.ZIP,
+});
+
+export const FILE_TYPE_FULL_NAMES = Object.freeze({
+    [FILE_TYPES.NONE]: "Plain Text",
+    [FILE_TYPES.CLP_IR]: "CLP IR Stream",
+    [FILE_TYPES.ZST]: "Zstandard",
+    [FILE_TYPES.TAR_GZ]: "Tarball Gzip",
+    [FILE_TYPES.GZ]: "Gzip",
+    [FILE_TYPES.ZIP]: "PKZip",
+});
+
+export const FILE_TYPE_MAGIC_NUMBERS = Object.freeze({
+    // NOTE: this magic number is checked AFTER Zstd decompression
+    [FILE_TYPES.CLP_IR]: new Uint8Array([0xFD, 0x2F, 0xB5, 0x29]),
+
+    // https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1
+    [FILE_TYPES.ZST]: new Uint8Array([0x28, 0xb5, 0x2f, 0xfd]),
+
+    // https://datatracker.ietf.org/doc/html/rfc1952#page-6
+    // 0x1f: ID1 (IDentification 1): (fixed)
+    // 0x8b: ID2 (IDentification 2): (fixed)
+    // 0x08: CM (Compression Method): DEFLATE
+    // 0x00: FLG (FLaGs): none is set; see below [FILE_TYPES.GZ]
+    [FILE_TYPES.TAR_GZ]: new Uint8Array([0x1f, 0x8b, 0x08, 0x00]),
+
+    // Similar to above except FLG
+    // 0x08: Bit 3 (FNAME) set in FLG (FLaGs), which means an original file name
+    //       is present, and likely that compressed stream is a single file.
+    [FILE_TYPES.GZ]: new Uint8Array([0x1f, 0x8b, 0x08, 0x08]),
+
+    // https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
+    [FILE_TYPES.ZIP]: new Uint8Array([0x50, 0x4b, 0x03, 0x04]),
+});
+
+// For below file types, recheck content type after first decompression
+export const FILE_TYPE_RECHECK_LIST = [
+    FILE_TYPES.ZST,
+];

--- a/src/Viewer/services/decoder/FILE_FORMATS.js
+++ b/src/Viewer/services/decoder/FILE_FORMATS.js
@@ -1,14 +1,13 @@
-let enumFileTypes;
-export const FILE_TYPES = Object.freeze({
-    NONE: (enumFileTypes = 0),
-    CLP_IR: ++enumFileTypes,
-    ZST: ++enumFileTypes,
-    GZ: ++enumFileTypes,
-    TAR_GZ: ++enumFileTypes,
-    ZIP: ++enumFileTypes,
+const FILE_TYPES = Object.freeze({
+    NONE: "none",
+    CLP_IR: "clp_ir",
+    ZST: "zst",
+    GZ: "gz",
+    TAR_GZ: "tar_gz",
+    ZIP: "zip",
 });
 
-export const FILE_EXTENSION_MAPS = Object.freeze({
+const FILE_EXTENSION_MAPS = Object.freeze({
     ".txt": FILE_TYPES.NONE,
     ".clp.zst": FILE_TYPES.CLP_IR,
     ".zst": FILE_TYPES.ZST,
@@ -18,7 +17,7 @@ export const FILE_EXTENSION_MAPS = Object.freeze({
     ".zip": FILE_TYPES.ZIP,
 });
 
-export const FILE_TYPE_FULL_NAMES = Object.freeze({
+const FILE_TYPE_FULL_NAMES = Object.freeze({
     [FILE_TYPES.NONE]: "Plain Text",
     [FILE_TYPES.CLP_IR]: "CLP IR Stream",
     [FILE_TYPES.ZST]: "Zstandard",
@@ -27,30 +26,39 @@ export const FILE_TYPE_FULL_NAMES = Object.freeze({
     [FILE_TYPES.ZIP]: "PKZip",
 });
 
-export const FILE_TYPE_MAGIC_NUMBERS = Object.freeze({
+const FILE_TYPE_MAGIC_NUMBERS = Object.freeze({
     // NOTE: this magic number is checked AFTER Zstd decompression
-    [FILE_TYPES.CLP_IR]: new Uint8Array([0xFD, 0x2F, 0xB5, 0x29]),
+    [FILE_TYPES.CLP_IR]: [0xFD, 0x2F, 0xB5, 0x29],
 
     // https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1
-    [FILE_TYPES.ZST]: new Uint8Array([0x28, 0xb5, 0x2f, 0xfd]),
+    [FILE_TYPES.ZST]: [0x28, 0xb5, 0x2f, 0xfd],
 
     // https://datatracker.ietf.org/doc/html/rfc1952#page-6
     // 0x1f: ID1 (IDentification 1): (fixed)
     // 0x8b: ID2 (IDentification 2): (fixed)
     // 0x08: CM (Compression Method): DEFLATE
     // 0x00: FLG (FLaGs): none is set; see below [FILE_TYPES.GZ]
-    [FILE_TYPES.TAR_GZ]: new Uint8Array([0x1f, 0x8b, 0x08, 0x00]),
+    [FILE_TYPES.TAR_GZ]: [0x1f, 0x8b, 0x08, 0x00],
 
     // Similar to above except FLG
     // 0x08: Bit 3 (FNAME) set in FLG (FLaGs), which means an original file name
     //       is present, and likely that compressed stream is a single file.
-    [FILE_TYPES.GZ]: new Uint8Array([0x1f, 0x8b, 0x08, 0x08]),
+    [FILE_TYPES.GZ]: [0x1f, 0x8b, 0x08, 0x08],
 
     // https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
-    [FILE_TYPES.ZIP]: new Uint8Array([0x50, 0x4b, 0x03, 0x04]),
+    [FILE_TYPES.ZIP]: [0x50, 0x4b, 0x03, 0x04],
 });
 
 // For below file types, recheck content type after first decompression
-export const FILE_TYPE_RECHECK_LIST = [
+const FILE_TYPE_RECHECK_LIST = [
     FILE_TYPES.ZST,
 ];
+
+
+export {
+    FILE_TYPES,
+    FILE_EXTENSION_MAPS,
+    FILE_TYPE_FULL_NAMES,
+    FILE_TYPE_MAGIC_NUMBERS,
+    FILE_TYPE_RECHECK_LIST,
+};

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -24,7 +24,7 @@ class FileManager {
      * against known magic numbers.
      *
      * @param {Uint8Array|ArrayBuffer} data
-     * @returns {string} The file's type as one of FILE_TYPES
+     * @return {string} The file's type as one of FILE_TYPES
      */
     static #getFileTypeByMagicNumber = (data) => {
         let fileType = FILE_TYPES.UNKNOWN;
@@ -56,7 +56,7 @@ class FileManager {
      * @private
      * @param {Uint8Array} data Compressed data
      * @param {string} name Original file name
-     * @returns {{content: ArrayBuffer, name: string}}
+     * @return {{content: ArrayBuffer, name: string}}
      * @throws {Error} if there was an issue loading or extracting the archive
      */
     static #getZstdFileContent = async (data, name) => {
@@ -79,7 +79,7 @@ class FileManager {
      * @private
      * @param {Uint8Array} data Compressed data
      * @param {string} name Original file name
-     * @returns {{content: Uint8Array, name: string}}
+     * @return {{content: Uint8Array, name: string}}
      * @throws {Error} if there was an issue loading or extracting the archive
      */
     static #getGzipFileContent = (data, name) => {
@@ -96,7 +96,7 @@ class FileManager {
      * @private
      * @param {Uint8Array} data Compressed data
      * @param {string} name Original file name
-     * @returns {{content: Uint8Array, name: string}} where name is the
+     * @return {{content: Uint8Array, name: string}} where name is the
      * original filename joined with the first file's name as a path.
      * @throws {Error} if there was an issue loading or extracting the archive
      */
@@ -122,7 +122,7 @@ class FileManager {
      * @private
      * @param {Uint8Array} data Compressed data
      * @param {string} name Original file name
-     * @returns {{content: Uint8Array, name: string}} where name is the
+     * @return {{content: Uint8Array, name: string}} where name is the
      * original filename joined with the first file's name as a path.
      * @throws {Error} if there was an issue loading or extracting the archive
      */
@@ -321,7 +321,7 @@ class FileManager {
      * @private
      * @param {Uint8Array} data
      * @param {string} name Original file name
-     * @returns {string} The file's type as one of FILE_TYPES
+     * @return {string} The file's type as one of FILE_TYPES
      */
     _getLogFileTypeBeforeDecompress (data, name) {
         let type = FileManager.#getFileTypeByMagicNumber(data);
@@ -350,7 +350,7 @@ class FileManager {
      * returns the decompressed data.
      *
      * @private
-     * @returns {Promise<Uint8Array|ArrayBuffer>}
+     * @return {Promise<Uint8Array|ArrayBuffer>}
      * @throws {Error} if there was an issue during decompression.
      */
     async _decompressFile () {
@@ -386,7 +386,7 @@ class FileManager {
      * @param {Uint8Array|ArrayBuffer} data
      * @param {string} typeBeforeDecode The file's type, determined before
      * decoding, as one of FILE_TYPES
-     * @returns {string} The file's real type as one of FILE_TYPES
+     * @return {string} The file's real type as one of FILE_TYPES
      */
     _getFileTypeBeforeDecode (data, typeBeforeDecode) {
         let type = typeBeforeDecode;

--- a/src/Viewer/services/decoder/FileManager.js
+++ b/src/Viewer/services/decoder/FileManager.js
@@ -56,7 +56,7 @@ class FileManager {
      * @private
      * @param {Uint8Array} data Compressed data
      * @param {string} name Original file name
-     * @return {{content: ArrayBuffer, name: string}}
+     * @return {Promise<{content: ArrayBuffer, name: string}>}
      * @throws {Error} if there was an issue loading or extracting the archive
      */
     static #getZstdFileContent = async (data, name) => {
@@ -122,7 +122,7 @@ class FileManager {
      * @private
      * @param {Uint8Array} data Compressed data
      * @param {string} name Original file name
-     * @return {{content: Uint8Array, name: string}} where name is the
+     * @return {Promise<{content: Uint8Array, name: string}>} where name is the
      * original filename joined with the first file's name as a path.
      * @throws {Error} if there was an issue loading or extracting the archive
      */


### PR DESCRIPTION
# Description
1. Refactor loading functions in FileManager.
2. Add dependency [axios](https://github.com/axios/axios) for HTTP requests.
3. Refactor file getters with `async` syntax.
4. Support determining file type from magic numbers.

# Validation performed
Tested the log viewer with the following log files on public S3 bucket as well as open them locally via drag and drop:

- https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst
- https://yscope.s3.us-east-2.amazonaws.com/sample-logs/zip-archive.zip
- https://yscope.s3.us-east-2.amazonaws.com/sample-logs/LICENSE.txt.zst
- https://yscope.s3.us-east-2.amazonaws.com/sample-logs/LICENSE.txt.gz
- https://yscope.s3.us-east-2.amazonaws.com/sample-logs/LICENSE.txt
- https://<local.server>/tar-gz-archive.tar.gz (https://yscope.s3.us-east-2.amazonaws.com/sample-logs/tar-gz-archive.tar.gz with first hidden file removed.)
- (Magic number type check) Renamed `tar-gz-archive.zip` from `LICENSE.txt.gz`.