### PR TITLE
Move ThemeContext and theme state management into a new ThemeContextProvider component.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,9 +2,7 @@ import React, {useEffect, useState} from "react";
 
 import config from "./config.json";
 import {DropFile} from "./DropFile/DropFile";
-import {THEME_STATES} from "./ThemeContext/THEME_STATES";
-import {ThemeContext} from "./ThemeContext/ThemeContext";
-import LOCAL_STORAGE_KEYS from "./Viewer/services/LOCAL_STORAGE_KEYS";
+import {ThemeContextProvider} from "./ThemeContext/ThemeContext";
 import {Viewer} from "./Viewer/Viewer";
 
 import "bootstrap/dist/css/bootstrap.min.css";
@@ -28,20 +26,12 @@ export function App () {
     const [logEventIdx, setLogEventIdx] = useState(null);
     const [timestamp, setTimestamp] = useState(null);
     const [prettify, setPrettify] = useState(null);
-    const [theme, setTheme] = useState(THEME_STATES.DARK);
+
 
     useEffect(() => {
         console.debug("Version:", config.version);
-        const lsTheme = localStorage.getItem(LOCAL_STORAGE_KEYS.UI_THEME);
-        switchTheme(THEME_STATES.LIGHT === lsTheme ?THEME_STATES.LIGHT :THEME_STATES.DARK);
         init();
     }, []);
-
-    const switchTheme = (theme) => {
-        localStorage.setItem(LOCAL_STORAGE_KEYS.UI_THEME, theme);
-        document.getElementById("app").setAttribute("data-theme", theme);
-        setTheme(theme);
-    };
 
     /**
      * Initializes the application's state. The file to load is set based on
@@ -86,7 +76,7 @@ export function App () {
 
     return (
         <div id="app">
-            <ThemeContext.Provider value={{theme, switchTheme}}>
+            <ThemeContextProvider>
                 <DropFile handleFileDrop={handleFileChange}>
                     {(APP_STATE.FILE_VIEW === appMode) &&
                         <Viewer logEventNumber={logEventIdx}
@@ -95,7 +85,7 @@ export function App () {
                             fileInfo={fileInfo}/>
                     }
                 </DropFile>
-            </ThemeContext.Provider>
+            </ThemeContextProvider>
         </div>
     );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -27,7 +27,6 @@ export function App () {
     const [timestamp, setTimestamp] = useState(null);
     const [prettify, setPrettify] = useState(null);
 
-
     useEffect(() => {
         console.debug("Version:", config.version);
         init();

--- a/src/ThemeContext/README.md
+++ b/src/ThemeContext/README.md
@@ -7,12 +7,11 @@ Exposes a provider which can wrap any YScope React component to manage themes.
 The sample application provided below demonstrates the configuration needed to 
 deploy the log viewer with drag&drop and theming using the Theme Context.
 
-```shell
-import React, { useState } from 'react';
+```js
+import React, {useState} from 'react';
 import reactDom from 'react-dom';
 import {DropFile} from "./DropFile/DropFile";
-import {THEME_STATES} from "./ThemeContext/THEME_STATES";
-import {ThemeContext} from "./ThemeContext/ThemeContext";
+import {ThemeContextProvider} from "./ThemeContext/ThemeContext";
 import {Viewer} from "./Viewer/Viewer";
 
 import "bootstrap/dist/css/bootstrap.min.css";
@@ -24,14 +23,7 @@ const App = () => {
     };
 
     const [fileInfo, setFileInfo] = useState(null);
-    const [theme, setTheme] = useState(THEME_STATES.DARK);
     const [appMode, setAppMode] = useState();
-
-    const switchTheme = (theme) => {
-        localStorage.setItem(LOCAL_STORAGE_KEYS.UI_THEME, theme);
-        document.getElementById("app").setAttribute("data-theme", theme);
-        setTheme(theme);
-    };
 
     const handleFileChange = (file) => {
         setFileInfo(file);
@@ -40,14 +32,12 @@ const App = () => {
     
     useEffect(() => {
         console.debug("Version:", config.version);
-        const lsTheme = localStorage.getItem(LOCAL_STORAGE_KEYS.UI_THEME);
-        switchTheme(lsTheme === THEME_STATES.LIGHT?THEME_STATES.LIGHT:THEME_STATES.DARK);
         setAppMode(APP_STATE.FILE_PROMPT);
     }, []);
 
     return (
         <div id="app">
-            <ThemeContext.Provider value={{theme, switchTheme}}>
+            <ThemeContextProvider>
                 <DropFile handleFileDrop={handleFileChange}>
                     {appMode === APP_STATE.VIEWER &&
                         <Viewer logEventNumber={333}
@@ -55,7 +45,7 @@ const App = () => {
                             fileInfo={fileInfo}/>
                     }
                 </DropFile>
-            </ThemeContext.Provider>
+            </ThemeContextProvider>
         </div>
     );
 }

--- a/src/ThemeContext/THEME_STATES.js
+++ b/src/ThemeContext/THEME_STATES.js
@@ -1,4 +1,0 @@
-export const THEME_STATES = {
-    LIGHT: 'light',
-    DARK: 'dark'
-};

--- a/src/ThemeContext/ThemeContext.js
+++ b/src/ThemeContext/ThemeContext.js
@@ -1,2 +1,55 @@
-import {createContext} from "react";
-export const ThemeContext = createContext({});
+import React, {
+    createContext, useEffect, useState
+} from "react";
+
+import PropTypes from "prop-types";
+
+import LOCAL_STORAGE_KEYS from "../Viewer/services/LOCAL_STORAGE_KEYS";
+import {THEME_NAMES} from "./constants";
+
+
+const DEFAULT_THEME_NAME = THEME_NAMES.DARK;
+
+const ThemeContext = createContext(DEFAULT_THEME_NAME);
+
+/**
+ * Provides a theme context for its children components.
+ *
+ * @param {React.ReactNode} children
+ * @return {JSX.Element}
+ */
+const ThemeContextProvider = ({children}) => {
+    const [theme, setTheme] = useState(DEFAULT_THEME_NAME);
+
+    const changeTheme = (newTheme) => {
+        localStorage.setItem(LOCAL_STORAGE_KEYS.UI_THEME, newTheme);
+        document.getElementById("app").setAttribute("data-theme", newTheme);
+        setTheme(newTheme);
+    };
+
+    useEffect(() => {
+        const lsTheme =
+            localStorage.getItem(LOCAL_STORAGE_KEYS.UI_THEME) || DEFAULT_THEME_NAME;
+
+        if (null !== lsTheme) {
+            changeTheme(lsTheme);
+        }
+    }, []);
+
+    return (
+        <ThemeContext.Provider
+            value={{
+                changeTheme,
+                theme,
+            }}
+        >
+            {children}
+        </ThemeContext.Provider>
+    );
+};
+
+ThemeContextProvider.propTypes = {
+    children: PropTypes.node,
+};
+
+export {ThemeContext, ThemeContextProvider};

--- a/src/ThemeContext/ThemeContext.js
+++ b/src/ThemeContext/ThemeContext.js
@@ -8,12 +8,17 @@ import LOCAL_STORAGE_KEYS from "../Viewer/services/LOCAL_STORAGE_KEYS";
 import {THEME_NAMES} from "./constants";
 
 
+/**
+ * A default theme name from the predefined THEME_NAMES.
+ * @type {string}
+ */
 const DEFAULT_THEME_NAME = THEME_NAMES.DARK;
 
 const ThemeContext = createContext(DEFAULT_THEME_NAME);
 
 /**
- * Provides a theme context for its children components.
+ * Provides a theme context for its child components
+ * and manages the theme state.
  *
  * @param {React.ReactNode} children
  * @return {JSX.Element}
@@ -21,20 +26,23 @@ const ThemeContext = createContext(DEFAULT_THEME_NAME);
 const ThemeContextProvider = ({children}) => {
     const [theme, setTheme] = useState(DEFAULT_THEME_NAME);
 
-    const changeTheme = (newTheme) => {
-        localStorage.setItem(LOCAL_STORAGE_KEYS.UI_THEME, newTheme);
-        document.getElementById("app").setAttribute("data-theme", newTheme);
-        setTheme(newTheme);
-    };
-
     useEffect(() => {
         const lsTheme =
             localStorage.getItem(LOCAL_STORAGE_KEYS.UI_THEME) || DEFAULT_THEME_NAME;
-
         if (null !== lsTheme) {
             changeTheme(lsTheme);
         }
     }, []);
+
+    /**
+     * Sets the theme for the application.
+     *
+     * @param {string} themeName one of the predefined THEME_NAMES
+     */
+    const changeTheme = (themeName) => {
+        localStorage.setItem(LOCAL_STORAGE_KEYS.UI_THEME, themeName);
+        setTheme(themeName);
+    };
 
     return (
         <ThemeContext.Provider

--- a/src/ThemeContext/constants.js
+++ b/src/ThemeContext/constants.js
@@ -1,0 +1,6 @@
+const THEME_NAMES = Object.freeze({
+    DARK: "dark",
+    LIGHT: "light",
+});
+
+export {THEME_NAMES};

--- a/src/Viewer/README.md
+++ b/src/Viewer/README.md
@@ -19,11 +19,11 @@ event number from the url.
 
 ### Example:
 `http://localhost:3010/?filePath=/logs/custom_app/high-compression-ratio-log.clp.zst&prettify=true&logEventIdx=100`
-```shell
+```js
 import React, { useState } from 'react';
 import reactDom from 'react-dom';
 import {DropFile} from "./DropFile/DropFile";
-import {THEME_STATES} from "./ThemeContext/THEME_STATES";
+import {THEME_NAMES} from "./ThemeContext/constants";
 import {ThemeContext} from "./ThemeContext/ThemeContext";
 import {Viewer} from "./Viewer/Viewer";
 
@@ -39,20 +39,11 @@ const App = () => {
     const [fileInfo, setFileInfo] = useState(null);
     const [logEventIdx, setLogEventIdx] = useState(null);
     const [prettify, setPrettify] = useState(null);
-    const [theme, setTheme] = useState(THEME_STATES.DARK);
 
     useEffect(() => {
         console.debug("Version:", config.version);
-        const lsTheme = localStorage.getItem(LOCAL_STORAGE_KEYS.UI_THEME);
-        switchTheme(THEME_STATES.LIGHT === lsTheme ?THEME_STATES.LIGHT :THEME_STATES.DARK);
         init();
     }, []);
-
-    const switchTheme = (theme) => {
-        localStorage.setItem(LOCAL_STORAGE_KEYS.UI_THEME, theme);
-        document.getElementById("app").setAttribute("data-theme", theme);
-        setTheme(theme);
-    };
 
     /**
      * Initializes the applications state. The file to load is set based on
@@ -97,7 +88,7 @@ const App = () => {
 
     return (
         <div id="app">
-            <ThemeContext.Provider value={{theme, switchTheme}}>
+            <ThemeContextProvider>
                 <DropFile handleFileDrop={handleFileChange}>
                     {(APP_STATE.FILE_VIEW === appMode) &&
                         <Viewer logEventNumber={logEventIdx}
@@ -105,7 +96,7 @@ const App = () => {
                             fileInfo={fileInfo}/>
                     }
                 </DropFile>
-            </ThemeContext.Provider>
+            </ThemeContextProvider>
         </div>
     );
 }

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -4,7 +4,7 @@ import PropTypes, {oneOfType} from "prop-types";
 import {Row} from "react-bootstrap";
 import LoadingIcons from "react-loading-icons";
 
-import {THEME_STATES} from "../ThemeContext/THEME_STATES";
+import {THEME_NAMES} from "../ThemeContext/constants";
 import {ThemeContext} from "../ThemeContext/ThemeContext";
 import {MenuBar} from "./components/MenuBar/MenuBar";
 import MonacoInstance from "./components/Monaco/MonacoInstance";
@@ -271,7 +271,7 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber, timestamp}) {
                 <div className="viewer-loading-container">
                     <Row className="m-0">
                         <LoadingIcons.Oval height="5em" stroke={
-                            (THEME_STATES.LIGHT === theme) ? "black" : "white"
+                            (THEME_NAMES.LIGHT === theme) ? "black" : "white"
                         }/>
                     </Row>
                     <Row className="loading-container">

--- a/src/Viewer/components/MenuBar/MenuBar.js
+++ b/src/Viewer/components/MenuBar/MenuBar.js
@@ -5,7 +5,7 @@ import {Button, Form, Modal, ProgressBar, Table} from "react-bootstrap";
 import {ChevronDoubleLeft, ChevronDoubleRight, ChevronLeft, ChevronRight,
     FileText, Folder, Gear, Keyboard, Moon, Sun} from "react-bootstrap-icons";
 
-import {THEME_STATES} from "../../../ThemeContext/THEME_STATES";
+import {THEME_NAMES} from "../../../ThemeContext/constants";
 import {ThemeContext} from "../../../ThemeContext/ThemeContext";
 import LOCAL_STORAGE_KEYS from "../../services/LOCAL_STORAGE_KEYS";
 import MODIFY_PAGE_ACTION from "../../services/MODIFY_PAGE_ACTION";
@@ -49,7 +49,7 @@ MenuBar.propTypes = {
 export function MenuBar ({
     logFileState, fileMetaData, loadingLogs, changeStateCallback, loadFileCallback,
 }) {
-    const {theme, switchTheme} = useContext(ThemeContext);
+    const {theme, changeTheme} = useContext(ThemeContext);
 
     const [eventsPerPage, setEventsPerPage] = useState(logFileState.pages);
     const [showSettings, setShowSettings] = useState(false);
@@ -101,7 +101,7 @@ export function MenuBar ({
 
     // Modal Functions
     const getModalClass = () => {
-        return (THEME_STATES.LIGHT === theme)?"modal-light":"modal-dark";
+        return (THEME_NAMES.LIGHT === theme)?"modal-light":"modal-dark";
     };
 
     const saveModalChanges = (e) => {
@@ -123,15 +123,15 @@ export function MenuBar ({
     };
 
     const getThemeIcon = () => {
-        if (THEME_STATES.LIGHT === theme) {
+        if (THEME_NAMES.LIGHT === theme) {
             return (
                 <Moon className="cursor-pointer" title="Set Light Mode"
-                    onClick={() => switchTheme(THEME_STATES.DARK)}/>
+                    onClick={() => changeTheme(THEME_NAMES.DARK)}/>
             );
-        } else if (THEME_STATES.DARK === theme) {
+        } else if (THEME_NAMES.DARK === theme) {
             return (
                 <Sun className="cursor-pointer" title="Set Dark Mode"
-                    onClick={() => switchTheme(THEME_STATES.LIGHT)}/>
+                    onClick={() => changeTheme(THEME_NAMES.LIGHT)}/>
             );
         }
     };

--- a/src/Viewer/components/Monaco/MonacoInstance.js
+++ b/src/Viewer/components/Monaco/MonacoInstance.js
@@ -3,7 +3,7 @@ import React, {useContext, useEffect, useRef} from "react";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 import PropTypes from "prop-types";
 
-import {THEME_STATES} from "../../../ThemeContext/THEME_STATES";
+import {THEME_NAMES} from "../../../ThemeContext/constants";
 import {ThemeContext} from "../../../ThemeContext/ThemeContext";
 import STATE_CHANGE_TYPE from "../../services/STATE_CHANGE_TYPE";
 import {SHORTCUTS} from "./Shortcuts";
@@ -264,7 +264,7 @@ function MonacoInstance ({
     };
 
     const getMonacoThemeName = (theme) => (
-        (theme === THEME_STATES.LIGHT) ? "customLogLanguageLight" : "customLogLanguageDark"
+        (theme === THEME_NAMES.LIGHT) ? "customLogLanguageLight" : "customLogLanguageDark"
     );
 
     return (


### PR DESCRIPTION
# References
Refactoring.

# Description
1. Add ThemeContextProvider to encapsulate all theme setting mechanisms, including interactions with local storage and the handling of theme switching.
2. Update docs.

# Validation performed
## Environment
Microsoft Edge
Version 121.0.2277.112 (Official build) (64-bit)
## Steps
1. `npm run start`. 
2. In a browser, cleared caches and localStorage for domain `localhost` and visited http://localhost:3010/. Observed the UI to be in default theme "dark".
3. Visited http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst#logEventIdx=375558 which displayed the Viewer interface after the logs finished loading. Observed the UI including the code editor to be in default theme "dark".
4. Opened "Settings" popup and changed theme to "light". Observed the UI including the code editor to be in theme "light".
5. Refreshed the page and observed the UI including the code editor to be in theme "light".
6. Repeat Steps 4-6 with theme "dark".