### PR TITLE
Optimise bundle size by correctly applying `MiniCssExtractPlugin` & stripping out unneeded `monaco-editor` features; add `analyze:size` npm config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@
 /.idea
 /.vscode
 
-# for bundle size anaylysis
+# for bundle size analysis
 /bundle_stats.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist
 node_modules
 package-lock.json
 .idea
+
+bundle_stats.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
-dist
-node_modules
-package-lock.json
-.idea
+# dependencies
+/node_modules
+/package-lock.json
 
-bundle_stats.json
+# production
+/dist
+
+# IDEs
+/.idea
+/.vscode
+
+# for bundle size anaylysis
+/bundle_stats.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "webpack --config webpack.prod.js",
     "start": "webpack serve --open --config webpack.dev.js",
-    "test": "jest"
+    "test": "jest",
+    "analyze:size": "npx webpack --config webpack.prod.js --profile --json > bundle_stats.json && npx webpack-bundle-analyzer bundle_stats.json dist/"
   },
   "repository": {
     "type": "git",
@@ -62,7 +63,7 @@
     "stylelint-config-standard": "^29.0.0",
     "stylelint-config-standard-scss": "^6.1.0",
     "webpack": "^5.74.0",
-    "webpack-bundle-analyzer": "^4.7.0",
+    "webpack-bundle-analyzer": "^4.10.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1",
     "webpack-merge": "^5.8.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "webpack --config webpack.prod.js",
     "start": "webpack serve --open --config webpack.dev.js",
     "test": "jest",
-    "analyze:size": "npx webpack --config webpack.prod.js --profile --json > bundle_stats.json && npx webpack-bundle-analyzer bundle_stats.json dist/"
+    "analyze:size": "npx webpack --config webpack.prod.js --profile --json=bundle_stats.json && npx webpack-bundle-analyzer bundle_stats.json dist/"
   },
   "repository": {
     "type": "git",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -10,28 +10,32 @@ module.exports = {
         }),
         new MonacoWebpackPlugin({
             features: [
-                "!suggest",
-                "!folding",
-                "!gotoSymbol",
-                "!linesOperations",
-                "!multicursor",
-                "!hover",
-                "!indentation",
-                "!codelens",
-                "!linkedEditing",
-                "!rename",
-                "!smartSelect",
-                "!snippet",
-                "!format",
-                "!gotoError",
-                "!diffEditor",
-                "!inPlaceReplace",
-                "!comment",
-                "!parameterHints",
-                "!colorPicker",
-                "!inlineProgress",
-                "!inlineCompletions",
-                "!inlayHints",
+                // code reading related
+                "!codelens", // similar to inlayHints, displays reference counts / VCS info
+                "!gotoError", // navigation to coding errors
+                "!gotoSymbol", // navigation to symbols
+                "!hover", // hover information (like tooltips)
+                "!inlayHints", // similar to codelens, displays type / parameter info
+                "!parameterHints", // parameter hints in functions/methods
+                "!smartSelect", // expand / contract selection based on code structure and syntax
+
+                // editing related
+                "!comment", // add / remove / toggle comments
+                "!format", // code formatting
+                "!inlineCompletions", // inline code completions
+                "!indentation", // auto indentation
+                "!inPlaceReplace", // replace code in place
+                "!linkedEditing", // simultaneously edit similar text elements (e.g. HTML)
+                "!linesOperations", // move / sort lines
+                "!multicursor", // multi-cursor simultaneous editing support
+                "!rename", // rename refactoring
+                "!snippet", // predefined code templates
+                "!suggest", // code suggestion
+
+                // tools
+                "!colorPicker", // color picker tool
+                "!diffEditor", // diff editor view
+                "!inlineProgress", // inline loading progress
             ],
             languages: ["ini"],
         }),

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -10,7 +10,7 @@ module.exports = {
         }),
         new MonacoWebpackPlugin({
             features: [
-                // code reading related
+                // Code reading related
                 "!codelens", // similar to inlayHints, displays reference counts / VCS info
                 "!gotoError", // navigation to coding errors
                 "!gotoSymbol", // navigation to symbols
@@ -19,7 +19,7 @@ module.exports = {
                 "!parameterHints", // parameter hints in functions/methods
                 "!smartSelect", // expand / contract selection based on code structure and syntax
 
-                // editing related
+                // Editing related
                 "!comment", // add / remove / toggle comments
                 "!format", // code formatting
                 "!inlineCompletions", // inline code completions
@@ -32,7 +32,7 @@ module.exports = {
                 "!snippet", // predefined code templates
                 "!suggest", // code suggestion
 
-                // tools
+                // Tools
                 "!colorPicker", // color picker tool
                 "!diffEditor", // diff editor view
                 "!inlineProgress", // inline loading progress

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 
@@ -9,9 +8,32 @@ module.exports = {
         new HtmlWebpackPlugin({
             template: path.resolve(__dirname, "src", "index.html"),
         }),
-        new MiniCssExtractPlugin(),
         new MonacoWebpackPlugin({
-            languages: ["ascii", "ini"],
+            features: [
+                "!suggest",
+                "!folding",
+                "!gotoSymbol",
+                "!linesOperations",
+                "!multicursor",
+                "!hover",
+                "!indentation",
+                "!codelens",
+                "!linkedEditing",
+                "!rename",
+                "!smartSelect",
+                "!snippet",
+                "!format",
+                "!gotoError",
+                "!diffEditor",
+                "!inPlaceReplace",
+                "!comment",
+                "!parameterHints",
+                "!colorPicker",
+                "!inlineProgress",
+                "!inlineCompletions",
+                "!inlayHints",
+            ],
+            languages: ["ini"],
         }),
     ],
     output: {
@@ -43,7 +65,7 @@ module.exports = {
             },
             {
                 test: /\.scss$/,
-                use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader"],
+                use: ["style-loader", "css-loader", "sass-loader"],
             },
             {
                 test: /\.css$/,

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,7 +1,31 @@
-const {merge} = require("webpack-merge");
+const {mergeWithRules} = require("webpack-merge");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
 const common = require("./webpack.common.js");
 
-module.exports = merge(common, {
+module.exports = mergeWithRules({
+    module: {
+        rules: {
+            test: "match",
+            use: "replace",
+        },
+    },
+})(common, {
     mode: "production",
     devtool: "source-map",
+    plugins: [
+        new MiniCssExtractPlugin(),
+    ],
+    module: {
+        rules: [
+            {
+                test: /\.scss$/,
+                use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader"],
+            },
+            {
+                test: /\.css$/,
+                use: [MiniCssExtractPlugin.loader, "css-loader"],
+            },
+        ],
+    },
 });


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
1. Optimise bundle size by correctly applying `MiniCssExtractPlugin`.
2. Optimise bundle size by stripping out unneeded `monaco-editor` features.
3. Add `analyze:size` npm config.
4. Upgrade dependency `webpack-bundle-analyzer` version from `4.7.0` to `4.10.1`.

# Validation performed
1. `npm run analyze:size` and viewed the module sizes in the hosted web page. 
   ### Before
   (bootstrap.min.css: 1,021,580 bytes)

   ![image](https://github.com/y-scope/yscope-log-viewer/assets/43196707/474e3166-0f53-471c-a8c1-1e8f342b5a24)

   ### After
   (bootstrap.min.css: 233,399 bytes)

   ![image](https://github.com/y-scope/yscope-log-viewer/assets/43196707/62a30ea4-5c77-47c3-8afc-4a5edbefaad7)

2. Compared "dist" sizes before and after the optimization. 
   ### Before
   32.6 MB (34,275,587 bytes)
   ### After
   28.8 MB (30,224,967 bytes)