### PR TITLE
Add support for IR format protocol version 0.0.2 except for gracefully ignoring UtcOffsetChange packets

### DIFF
--- a/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
+++ b/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
@@ -149,7 +149,8 @@ class FourByteClpIrStreamProtocolDecoder {
 
     readAndValidateEncodingType (dataInputStream) {
         for (let i = 0; i < PROTOCOL.FOUR_BYTE_ENCODING_MAGIC_NUMBER.length; ++i) {
-            if (PROTOCOL.FOUR_BYTE_ENCODING_MAGIC_NUMBER[i] !== dataInputStream.readUnsignedByte()) {
+            if (PROTOCOL.FOUR_BYTE_ENCODING_MAGIC_NUMBER[i] !== dataInputStream.readUnsignedByte())
+            {
                 throw new Error("IR stream doesn't use the four-byte encoding.");
             }
         }

--- a/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
+++ b/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
@@ -139,8 +139,6 @@ class FourByteClpIrStreamProtocolDecoder {
             case PROTOCOL.PAYLOAD.TIMESTAMP_DELTA_SIGNED_LONG:
                 timestampDelta = dataInputStream.readSignedLong();
                 break;
-            case PROTOCOL.PAYLOAD.TIMESTAMP_NULL:
-                return PROTOCOL.PAYLOAD.TIMESTAMP_NULL_VAL;
             default:
                 throw new Error("Timestamp missing from stream.");
         }
@@ -151,8 +149,7 @@ class FourByteClpIrStreamProtocolDecoder {
 
     readAndValidateEncodingType (dataInputStream) {
         for (let i = 0; i < PROTOCOL.FOUR_BYTE_ENCODING_MAGIC_NUMBER.length; ++i) {
-            if (PROTOCOL.FOUR_BYTE_ENCODING_MAGIC_NUMBER[i] !== dataInputStream.readUnsignedByte())
-            {
+            if (PROTOCOL.FOUR_BYTE_ENCODING_MAGIC_NUMBER[i] !== dataInputStream.readUnsignedByte()) {
                 throw new Error("IR stream doesn't use the four-byte encoding.");
             }
         }

--- a/src/Viewer/services/decoder/FourByteClpIrStreamReader.js
+++ b/src/Viewer/services/decoder/FourByteClpIrStreamReader.js
@@ -220,8 +220,9 @@ class FourByteClpIrStreamReader {
 
     /**
      * Reads a log event from the stream
-     * @return {{timestamp: bigint, verbosityIx: number, numValidVars: number} | null} The log event's timestamp,
-     * verbosity index, and number of valid variables; or null if no message is corresponding to the log event
+     * @return {{timestamp: bigint, verbosityIx: number, numValidVars: number} | null}
+     * The log event's timestamp, verbosity index, and number of valid variables
+     * or null if no log events were read but the stream may contain more events
      * @throws {FourByteClpIrStreamReaderEOFError} on EOF
      * @private
      */
@@ -230,7 +231,7 @@ class FourByteClpIrStreamReader {
         if (PROTOCOL.PAYLOAD.EOF === tag) {
             throw new FourByteClpIrStreamReaderEOFError();
         } else if (PROTOCOL.PAYLOAD.TIMESTAMP_UTC_OFFSET_CHANGE === tag) {
-            // TODO: add support for UTC offset changes
+            // TODO: add formatting support for UTC offset changes
             // Drain the int64 packet
             this._dataInputStream.readSignedLong();
             return null;

--- a/src/Viewer/services/decoder/IRTokenDecoder.js
+++ b/src/Viewer/services/decoder/IRTokenDecoder.js
@@ -26,7 +26,7 @@ class IRTokenDecoder {
     }
 
     decodeTimestamp (outputResizableBuffer, timestamp) {
-        if (timestamp >= BigInt(0) && PROTOCOL.PAYLOAD.TIMESTAMP_NULL_VAL !== timestamp) {
+        if (timestamp >= 0n) {
             // NOTE: Since we don't specify a timezone, JavaScript will use the
             // user's local  timezone. This should be more convenient for the
             // user.

--- a/src/Viewer/services/decoder/PROTOCOL.js
+++ b/src/Viewer/services/decoder/PROTOCOL.js
@@ -2,7 +2,7 @@ const PROTOCOL = {
     FOUR_BYTE_ENCODING_MAGIC_NUMBER: [0xFD, 0x2F, 0xB5, 0x29],
     METADATA: {
         VERSION_KEY: "VERSION",
-        VERSION_VALUE: "0.0.1",
+        VERSION_VALUE: "0.0.2",
         // The following regex can be used to validate a Semantic Versioning
         // string. The source of the regex can be found here: https://semver.org
         VERSION_REGEX: new RegExp("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"
@@ -34,10 +34,7 @@ const PROTOCOL = {
         TIMESTAMP_DELTA_SIGNED_SHORT: 0x32,
         TIMESTAMP_DELTA_SIGNED_INT: 0x33,
         TIMESTAMP_DELTA_SIGNED_LONG: 0x34,
-        TIMESTAMP_NULL: 0x3F,
-        // NOTE: JavaScript only supports 53-bit numbers safely, so we have to
-        //       use BigInt for 64-bit numbers.
-        TIMESTAMP_NULL_VAL: BigInt("-9223372036854776000"),
+        TIMESTAMP_UTC_OFFSET_CHANGE: 0x3F,
 
         isNotVar: (tag) => {
             return (tag >> 4) !== 0x1;


### PR DESCRIPTION
# References
[clp UtcOffsetChange PR](https://github.com/y-scope/clp/pull/386)

# Description
As mentioned in the reference, clp now has a `UtcOffsetChange` packet in its IR stream. This PR ignores this packet so that log viewer won't give out errors when opening this format.

To properly handle this, a `TIMESTAMP_UTC_OFFSET_CHANGE` tag is added to `PROTOCOL.js` with value `0x3F`. `TIMESTAMP_NULL` and `TIMESTAMP_NULL_VAL` are removed accordingly because:
1. No one is currently using these variables;
2. The current value of `TIMESTAMP_NULL` conflicts with the new value `TIMESTAMP_UTC_OFFSET_CHANGE`.

Then in `FourByteClpIrStreamReader.js`, `_readLogEvent` catches `TIMESTAMP_UTC_OFFSET_CHANGE` tag and then drop the 64 bit packet.

# Validation performed
- Successfully loaded a [four-byte IR v0.0.2 compressed file](https://github.com/user-attachments/files/16087675/four-byte.clp.zst.zip) (decompress `four-byte.clp.zst.zip` to `four-byte.clp.zst` first)
- Successfully loaded a [IR v0.0.1 file](https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst)
