### PR TITLE
Resolve relative filePath URLs as absolute.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import React, {useEffect, useState} from "react";
 import config from "./config.json";
 import {DropFile} from "./DropFile/DropFile";
 import {ThemeContextProvider} from "./ThemeContext/ThemeContext";
+import {getAbsoluteUrl} from "./Viewer/services/utils";
 import {Viewer} from "./Viewer/Viewer";
 
 import "bootstrap/dist/css/bootstrap.min.css";
@@ -52,7 +53,8 @@ export function App () {
 
         const filePath = urlSearchParams.get("filePath");
         if (null !== filePath) {
-            setFileInfo(filePath);
+            const absoluteUrl = getAbsoluteUrl(filePath);
+            setFileInfo(absoluteUrl);
             setAppMode(APP_STATE.FILE_VIEW);
         } else {
             if (null !== config.defaultFileUrl) {

--- a/src/Viewer/services/utils.js
+++ b/src/Viewer/services/utils.js
@@ -44,11 +44,12 @@ const modifyPage = (action, currentPage, requestedPage, pages) => {
 };
 
 /**
- * Returns an absolute URL of a given path relative to the window.location,
- * if the given path is a relative reference.
+ * Gets an absolute URL composed of a given path relative to the
+ * window.location, if the given path is a relative reference; otherwise
+ * the given path is returned verbatim.
  *
  * @param {string} path The path to be resolved.
- * @return {string} The absolute URL as a string.
+ * @return {string} The absolute URL of the given path.
  * @throws {Error} if the given `path` is a relative reference but invalid.
  */
 const getAbsoluteUrl = (path) => {

--- a/src/Viewer/services/utils.js
+++ b/src/Viewer/services/utils.js
@@ -44,6 +44,25 @@ const modifyPage = (action, currentPage, requestedPage, pages) => {
 };
 
 /**
+ * Returns an absolute URL of a given path relative to the window.location,
+ * if the given path is a relative reference.
+ *
+ * @param {string} path The path to be resolved.
+ * @return {string} The absolute URL as a string.
+ * @throws {Error} if the given `path` is a relative reference but invalid.
+ */
+const getAbsoluteUrl = (path) => {
+    try {
+        // eslint-disable-next-line no-new
+        new URL(path);
+    } catch (e) {
+        path = new URL(path, window.location.origin).href;
+    }
+
+    return path;
+};
+
+/**
  * Get modified URL from `window.location` based on the provided search and
  * hash parameters.
  *
@@ -147,4 +166,4 @@ function binarySearchWithTimestamp (timestamp, logEventMetadata) {
     return null;
 }
 
-export {binarySearchWithTimestamp, getModifiedUrl, isNumeric, modifyPage};
+export {binarySearchWithTimestamp, getAbsoluteUrl, getModifiedUrl, isNumeric, modifyPage};


### PR DESCRIPTION
# References
When users wish to load a CLP IR from the same origin of the Log Viewer host, to avoid repeating the log viewer's host url in the `filePath` URL parameter, we want to support the use case of supplying a relative path in `filePath`.

# Description
1. Resolve relative filePath URLs to absolute.

# Validation performed
1. Placed test file test-0.0.1.clp.zst under <log-viewer-root>/dist
2. Loaded http://localhost:3010/?filePath=/test-0.0.1.clp.zst in a browser.
3. Observed the file gets loaded successfully and the URL in the browser address bar got updated to http://localhost:3010/?filePath=http://localhost:3010/test-0.0.1.clp.zst#logEventIdx=375558 .