### PR TITLE
new-log-viewer: Formalize config parameters and add management utilities.

### DIFF
--- a/new-log-viewer/src/components/Layout.tsx
+++ b/new-log-viewer/src/components/Layout.tsx
@@ -7,7 +7,7 @@ import {
     UrlContext,
 } from "../contexts/UrlContextProvider";
 import {
-    CONFIG_CODE,
+    CONFIG_KEY,
     THEME_NAME,
 } from "../typings/config";
 import {
@@ -18,31 +18,31 @@ import {
 
 const formFields = [
     {
-        initialValue: getConfig(CONFIG_CODE.DECODER_OPTIONS).formatString,
+        initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).formatString,
         label: "decoderOptions/formatString",
         name: "formatString",
         type: "text",
     },
     {
-        initialValue: getConfig(CONFIG_CODE.DECODER_OPTIONS).logLevelKey,
+        initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).logLevelKey,
         label: "decoderOptions/logLevelKey",
         name: "logLevelKey",
         type: "text",
     },
     {
-        initialValue: getConfig(CONFIG_CODE.DECODER_OPTIONS).timestampKey,
+        initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).timestampKey,
         label: "decoderOptions/timestampKey",
         name: "timestampKey",
         type: "text",
     },
     {
-        initialValue: getConfig(CONFIG_CODE.THEME),
+        initialValue: getConfig(CONFIG_KEY.THEME),
         label: "Theme",
         name: "theme",
         type: "text",
     },
     {
-        initialValue: getConfig(CONFIG_CODE.PAGE_SIZE),
+        initialValue: getConfig(CONFIG_KEY.PAGE_SIZE),
         label: "Page Size",
         name: "pageSize",
         type: "number",
@@ -77,19 +77,19 @@ const ConfigForm = () => {
             "string" === typeof timestampKey
         ) {
             error ||= setConfig({
-                code: CONFIG_CODE.DECODER_OPTIONS,
+                key: CONFIG_KEY.DECODER_OPTIONS,
                 value: {formatString, logLevelKey, timestampKey},
             });
         }
         if ("string" === typeof theme) {
             error ||= setConfig({
-                code: CONFIG_CODE.THEME,
+                key: CONFIG_KEY.THEME,
                 value: theme as THEME_NAME,
             });
         }
         if ("string" === typeof pageSize) {
             error ||= setConfig({
-                code: CONFIG_CODE.PAGE_SIZE,
+                key: CONFIG_KEY.PAGE_SIZE,
                 value: Number(pageSize),
             });
         }

--- a/new-log-viewer/src/components/Layout.tsx
+++ b/new-log-viewer/src/components/Layout.tsx
@@ -6,7 +6,128 @@ import {
     updateWindowUrlHashParams,
     UrlContext,
 } from "../contexts/UrlContextProvider";
+import {CONFIG_CODE} from "../typings/config";
+import {
+    getConfig,
+    setConfig,
+} from "../utils/config";
 
+
+const formFields = [
+    {
+        initialValue: getConfig(CONFIG_CODE.DECODER_OPTIONS).formatString,
+        label: "decoderOptions/formatString",
+        name: "formatString",
+        type: "text",
+    },
+    {
+        initialValue: getConfig(CONFIG_CODE.DECODER_OPTIONS).logLevelKey,
+        label: "decoderOptions/logLevelKey",
+        name: "logLevelKey",
+        type: "text",
+    },
+    {
+        initialValue: getConfig(CONFIG_CODE.DECODER_OPTIONS).timestampKey,
+        label: "decoderOptions/timestampKey",
+        name: "timestampKey",
+        type: "text",
+    },
+    {
+        initialValue: getConfig(CONFIG_CODE.THEME),
+        label: "Theme",
+        name: "theme",
+        type: "text",
+    },
+    {
+        initialValue: getConfig(CONFIG_CODE.PAGE_SIZE),
+        label: "Page Size",
+        name: "pageSize",
+        type: "number",
+    },
+];
+
+/**
+ * Renders a form for testing config utilities.
+ *
+ * @return
+ */
+const ConfigForm = () => {
+    const handleConfigFormReset = (ev: React.FormEvent) => {
+        ev.preventDefault();
+        window.localStorage.clear();
+        window.location.reload();
+    };
+
+    const handleConfigFormSubmit = (ev: React.FormEvent) => {
+        ev.preventDefault();
+        const formData = new FormData(ev.target as HTMLFormElement);
+
+        const formatString = formData.get("formatString");
+        const logLevelKey = formData.get("logLevelKey");
+        const timestampKey = formData.get("timestampKey");
+        const theme = formData.get("theme");
+        const pageSize = formData.get("pageSize");
+        let error = null;
+        if (
+            "string" === typeof formatString &&
+            "string" === typeof logLevelKey &&
+            "string" === typeof timestampKey
+        ) {
+            error ||= setConfig({
+                code: CONFIG_CODE.DECODER_OPTIONS,
+                value: {formatString, logLevelKey, timestampKey},
+            });
+        }
+        if ("string" === typeof theme) {
+            error ||= setConfig({
+                code: CONFIG_CODE.THEME,
+                value: theme,
+            });
+        }
+        if ("string" === typeof pageSize) {
+            error ||= setConfig({
+                code: CONFIG_CODE.PAGE_SIZE,
+                value: Number(pageSize),
+            });
+        }
+        if (null !== error) {
+            // eslint-disable-next-line no-alert
+            window.alert(error);
+        } else {
+            window.location.reload();
+        }
+    };
+
+    return (
+        <form
+            onReset={handleConfigFormReset}
+            onSubmit={handleConfigFormSubmit}
+        >
+            <table>
+                <tbody>
+                    {formFields.map((field, index) => (
+                        <tr key={index}>
+                            <td>
+                                {field.label}
+                            </td>
+                            <td>
+                                <input
+                                    defaultValue={field.initialValue}
+                                    name={field.name}
+                                    size={100}
+                                    type={field.type}/>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            <div>
+                <button type={"submit"}>Apply</button>
+                <button type={"reset"}>Clear localStorage</button>
+            </div>
+        </form>
+    );
+};
 
 /**
  * Renders the major layout of the log viewer.
@@ -51,6 +172,8 @@ const Layout = () => {
                 <button onClick={handleCopyLinkButtonClick}>
                     Copy link to last log
                 </button>
+
+                <ConfigForm/>
 
                 {logData.split("\n").map((line, index) => (
                     <p key={index}>

--- a/new-log-viewer/src/components/Layout.tsx
+++ b/new-log-viewer/src/components/Layout.tsx
@@ -6,7 +6,10 @@ import {
     updateWindowUrlHashParams,
     UrlContext,
 } from "../contexts/UrlContextProvider";
-import {CONFIG_CODE} from "../typings/config";
+import {
+    CONFIG_CODE,
+    THEME_NAME,
+} from "../typings/config";
 import {
     getConfig,
     setConfig,
@@ -81,7 +84,7 @@ const ConfigForm = () => {
         if ("string" === typeof theme) {
             error ||= setConfig({
                 code: CONFIG_CODE.THEME,
-                value: theme,
+                value: theme as THEME_NAME,
             });
         }
         if ("string" === typeof pageSize) {

--- a/new-log-viewer/src/components/Layout.tsx
+++ b/new-log-viewer/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import {
 } from "../contexts/UrlContextProvider";
 import {
     CONFIG_KEY,
+    LOCAL_STORAGE_KEY,
     THEME_NAME,
 } from "../typings/config";
 import {
@@ -19,32 +20,32 @@ import {
 const formFields = [
     {
         initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).formatString,
-        label: "decoderOptions/formatString",
-        name: "formatString",
+        label: LOCAL_STORAGE_KEY.DECODER_OPTIONS_FORMAT_STRING,
+        name: LOCAL_STORAGE_KEY.DECODER_OPTIONS_FORMAT_STRING,
         type: "text",
     },
     {
         initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).logLevelKey,
-        label: "decoderOptions/logLevelKey",
-        name: "logLevelKey",
+        label: LOCAL_STORAGE_KEY.DECODER_OPTIONS_LOG_LEVEL_KEY,
+        name: LOCAL_STORAGE_KEY.DECODER_OPTIONS_LOG_LEVEL_KEY,
         type: "text",
     },
     {
         initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).timestampKey,
-        label: "decoderOptions/timestampKey",
-        name: "timestampKey",
+        label: LOCAL_STORAGE_KEY.DECODER_OPTIONS_TIMESTAMP_KEY,
+        name: LOCAL_STORAGE_KEY.DECODER_OPTIONS_TIMESTAMP_KEY,
         type: "text",
     },
     {
         initialValue: getConfig(CONFIG_KEY.THEME),
-        label: "Theme",
-        name: "theme",
+        label: LOCAL_STORAGE_KEY.THEME,
+        name: LOCAL_STORAGE_KEY.THEME,
         type: "text",
     },
     {
         initialValue: getConfig(CONFIG_KEY.PAGE_SIZE),
-        label: "Page Size",
-        name: "pageSize",
+        label: LOCAL_STORAGE_KEY.PAGE_SIZE,
+        name: LOCAL_STORAGE_KEY.PAGE_SIZE,
         type: "number",
     },
 ];
@@ -65,11 +66,11 @@ const ConfigForm = () => {
         ev.preventDefault();
         const formData = new FormData(ev.target as HTMLFormElement);
 
-        const formatString = formData.get("formatString");
-        const logLevelKey = formData.get("logLevelKey");
-        const timestampKey = formData.get("timestampKey");
-        const theme = formData.get("theme");
-        const pageSize = formData.get("pageSize");
+        const formatString = formData.get(LOCAL_STORAGE_KEY.DECODER_OPTIONS_FORMAT_STRING);
+        const logLevelKey = formData.get(LOCAL_STORAGE_KEY.DECODER_OPTIONS_LOG_LEVEL_KEY);
+        const timestampKey = formData.get(LOCAL_STORAGE_KEY.DECODER_OPTIONS_TIMESTAMP_KEY);
+        const theme = formData.get(LOCAL_STORAGE_KEY.THEME);
+        const pageSize = formData.get(LOCAL_STORAGE_KEY.PAGE_SIZE);
         let error = null;
         if (
             "string" === typeof formatString &&

--- a/new-log-viewer/src/contexts/StateContextProvider.tsx
+++ b/new-log-viewer/src/contexts/StateContextProvider.tsx
@@ -8,7 +8,7 @@ import React, {
 } from "react";
 
 import {Nullable} from "../typings/common";
-import {CONFIG_CODE} from "../typings/config";
+import {CONFIG_KEY} from "../typings/config";
 import {
     BeginLineNumToLogEventNumMap,
     CURSOR_CODE,
@@ -158,9 +158,9 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
         mainWorkerRef.current.onmessage = handleMainWorkerResp;
         mainWorkerPostReq(WORKER_REQ_CODE.LOAD_FILE, {
             fileSrc: fileSrc,
-            pageSize: getConfig(CONFIG_CODE.PAGE_SIZE),
+            pageSize: getConfig(CONFIG_KEY.PAGE_SIZE),
             cursor: cursor,
-            decoderOptions: getConfig(CONFIG_CODE.DECODER_OPTIONS),
+            decoderOptions: getConfig(CONFIG_KEY.DECODER_OPTIONS),
         });
     }, [
         handleMainWorkerResp,
@@ -178,7 +178,7 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
             return;
         }
 
-        numPagesRef.current = getChunkNum(numEvents, getConfig(CONFIG_CODE.PAGE_SIZE));
+        numPagesRef.current = getChunkNum(numEvents, getConfig(CONFIG_KEY.PAGE_SIZE));
     }, [numEvents]);
 
     // On `logEventNum` update, clamp it then switch page if necessary or simply update the URL.
@@ -188,7 +188,7 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
         }
 
         const newPageNum = clamp(
-            getChunkNum(logEventNum, getConfig(CONFIG_CODE.PAGE_SIZE)),
+            getChunkNum(logEventNum, getConfig(CONFIG_KEY.PAGE_SIZE)),
             1,
             numPagesRef.current
         );
@@ -203,7 +203,7 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
             // `WORKER_REQ_CODE.LOAD_PAGE` requests) .
             mainWorkerPostReq(WORKER_REQ_CODE.LOAD_PAGE, {
                 cursor: {code: CURSOR_CODE.PAGE_NUM, args: {pageNum: newPageNum}},
-                decoderOptions: getConfig(CONFIG_CODE.DECODER_OPTIONS),
+                decoderOptions: getConfig(CONFIG_KEY.DECODER_OPTIONS),
             });
         }
 
@@ -226,7 +226,7 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
             // NOTE: Since we don't know how many pages the log file contains, we only clamp the
             // minimum of the page number.
             const newPageNum = Math.max(
-                getChunkNum(logEventNumRef.current, getConfig(CONFIG_CODE.PAGE_SIZE)),
+                getChunkNum(logEventNumRef.current, getConfig(CONFIG_KEY.PAGE_SIZE)),
                 1
             );
 

--- a/new-log-viewer/src/contexts/StateContextProvider.tsx
+++ b/new-log-viewer/src/contexts/StateContextProvider.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 
 import {Nullable} from "../typings/common";
+import {CONFIG_NAME} from "../typings/config";
 import {
     BeginLineNumToLogEventNumMap,
     CURSOR_CODE,
@@ -18,7 +19,7 @@ import {
     WORKER_RESP_CODE,
     WorkerReq,
 } from "../typings/worker";
-import {DECODER_OPTIONS_DEFAULT} from "../utils/config";
+import {getConfig} from "../utils/config";
 import {
     clamp,
     getChunkNum,
@@ -205,12 +206,7 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
             // `WORKER_REQ_CODE.LOAD_PAGE` requests) .
             mainWorkerPostReq(WORKER_REQ_CODE.LOAD_PAGE, {
                 cursor: {code: CURSOR_CODE.PAGE_NUM, args: {pageNum: newPageNum}},
-                decoderOptions: {
-                    // TODO: these shall come from config provider
-                    formatString: DECODER_OPTIONS_DEFAULT.formatString,
-                    logLevelKey: DECODER_OPTIONS_DEFAULT.logLevelKey,
-                    timestampKey: DECODER_OPTIONS_DEFAULT.timestampKey,
-                },
+                decoderOptions: getConfig(CONFIG_NAME.DECODER_OPTIONS),
             });
         }
 

--- a/new-log-viewer/src/contexts/StateContextProvider.tsx
+++ b/new-log-viewer/src/contexts/StateContextProvider.tsx
@@ -18,6 +18,7 @@ import {
     WORKER_RESP_CODE,
     WorkerReq,
 } from "../typings/worker";
+import {DECODER_OPTIONS_DEFAULT} from "../utils/config";
 import {
     clamp,
     getChunkNum,
@@ -206,10 +207,9 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
                 cursor: {code: CURSOR_CODE.PAGE_NUM, args: {pageNum: newPageNum}},
                 decoderOptions: {
                     // TODO: these shall come from config provider
-                    formatString: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%process.thread.name] %log.level" +
-                        " %message%n",
-                    logLevelKey: "log.level",
-                    timestampKey: "@timestamp",
+                    formatString: DECODER_OPTIONS_DEFAULT.formatString,
+                    logLevelKey: DECODER_OPTIONS_DEFAULT.logLevelKey,
+                    timestampKey: DECODER_OPTIONS_DEFAULT.timestampKey,
                 },
             });
         }

--- a/new-log-viewer/src/typings/config.ts
+++ b/new-log-viewer/src/typings/config.ts
@@ -1,11 +1,18 @@
 import {JsonlDecoderOptionsType} from "./decoders";
 
 
+enum THEME_NAME {
+    SYSTEM = "system",
+    DARK = "dark",
+    LIGHT = "light",
+}
+
 enum CONFIG_CODE {
     DECODER_OPTIONS = "decoderOptions",
     THEME = "theme",
     PAGE_SIZE = "pageSize",
 }
+
 
 /* eslint-disable @typescript-eslint/prefer-literal-enum-member */
 enum LOCAL_STORAGE_KEY {
@@ -19,7 +26,7 @@ enum LOCAL_STORAGE_KEY {
 
 type ConfigMap = {
     [CONFIG_CODE.DECODER_OPTIONS]: JsonlDecoderOptionsType,
-    [CONFIG_CODE.THEME]: string,
+    [CONFIG_CODE.THEME]: THEME_NAME,
     [CONFIG_CODE.PAGE_SIZE]: number,
 };
 
@@ -33,6 +40,7 @@ type ConfigUpdate = {
 export {
     CONFIG_CODE,
     LOCAL_STORAGE_KEY,
+    THEME_NAME,
 };
 export type {
     ConfigMap,

--- a/new-log-viewer/src/typings/config.ts
+++ b/new-log-viewer/src/typings/config.ts
@@ -13,7 +13,6 @@ enum CONFIG_CODE {
     PAGE_SIZE = "pageSize",
 }
 
-
 /* eslint-disable @typescript-eslint/prefer-literal-enum-member */
 enum LOCAL_STORAGE_KEY {
     DECODER_OPTIONS_FORMAT_STRING = `${CONFIG_CODE.DECODER_OPTIONS}/formatString`,

--- a/new-log-viewer/src/typings/config.ts
+++ b/new-log-viewer/src/typings/config.ts
@@ -1,36 +1,40 @@
-enum CONFIG_NAME {
+import {JsonlDecoderOptionsType} from "./decoders";
+
+
+enum CONFIG_CODE {
     DECODER_OPTIONS = "decoderOptions",
     THEME = "theme",
     PAGE_SIZE = "pageSize",
 }
 
+/* eslint-disable @typescript-eslint/prefer-literal-enum-member */
 enum LOCAL_STORAGE_KEY {
-    DECODER_OPTIONS_FORMAT_STRING = `${CONFIG_NAME.DECODER_OPTIONS}/formatString`,
-    DECODER_OPTIONS_LOG_LEVEL_KEY = `${CONFIG_NAME.DECODER_OPTIONS}/logLevelKey`,
-    DECODER_OPTIONS_TIMESTAMP_KEY = `${CONFIG_NAME.DECODER_OPTIONS}/timestampKey`,
-    THEME = CONFIG_NAME.THEME,
-    PAGE_SIZE = CONFIG_NAME.PAGE_SIZE,
+    DECODER_OPTIONS_FORMAT_STRING = `${CONFIG_CODE.DECODER_OPTIONS}/formatString`,
+    DECODER_OPTIONS_LOG_LEVEL_KEY = `${CONFIG_CODE.DECODER_OPTIONS}/logLevelKey`,
+    DECODER_OPTIONS_TIMESTAMP_KEY = `${CONFIG_CODE.DECODER_OPTIONS}/timestampKey`,
+    THEME = CONFIG_CODE.THEME,
+    PAGE_SIZE = CONFIG_CODE.PAGE_SIZE,
 }
+/* eslint-enable @typescript-eslint/prefer-literal-enum-member */
 
 type ConfigMap = {
-    [CONFIG_NAME.DECODER_OPTIONS]: {
-        formatString: string,
-        logLevelKey: string,
-        timestampKey: string,
-    },
-    [CONFIG_NAME.THEME]: string,
-    [CONFIG_NAME.PAGE_SIZE]: number,
-}
-
-type ConfigValueType<T extends CONFIG_NAME>= { code: T, value: ConfigMap[T] | null};
+    [CONFIG_CODE.DECODER_OPTIONS]: JsonlDecoderOptionsType,
+    [CONFIG_CODE.THEME]: string,
+    [CONFIG_CODE.PAGE_SIZE]: number,
+};
 
 type ConfigUpdate = {
-    [T in keyof ConfigMap]: ConfigValueType<T>;
+    [T in keyof ConfigMap]: {
+        code: T;
+        value: ConfigMap[T];
+    }
 }[keyof ConfigMap];
 
 export {
-    CONFIG_NAME, LOCAL_STORAGE_KEY,
+    CONFIG_CODE,
+    LOCAL_STORAGE_KEY,
 };
 export type {
-    ConfigMap, ConfigUpdate, ConfigValueType,
+    ConfigMap,
+    ConfigUpdate,
 };

--- a/new-log-viewer/src/typings/config.ts
+++ b/new-log-viewer/src/typings/config.ts
@@ -1,0 +1,34 @@
+enum CONFIG_NAME {
+    DECODER_OPTIONS = "decoderOptions",
+    THEME = "theme",
+    PAGE_SIZE = "pageSize",
+}
+
+enum LOCAL_STORAGE_KEY {
+    DECODER_OPTIONS_FORMAT_STRING = `${CONFIG_NAME.DECODER_OPTIONS}/formatString`,
+    DECODER_OPTIONS_LOG_LEVEL_KEY = `${CONFIG_NAME.DECODER_OPTIONS}/logLevelKey`,
+    DECODER_OPTIONS_TIMESTAMP_KEY = `${CONFIG_NAME.DECODER_OPTIONS}/timestampKey`,
+    THEME = CONFIG_NAME.THEME,
+    PAGE_SIZE = CONFIG_NAME.PAGE_SIZE,
+}
+
+type ConfigMap = {
+    [CONFIG_NAME.DECODER_OPTIONS]: {
+        formatString: string,
+        logLevelKey: string,
+        timestampKey: string,
+    },
+    [CONFIG_NAME.THEME]: string,
+    [CONFIG_NAME.PAGE_SIZE]: number,
+}
+
+type ConfigUpdate = {
+    [T in keyof ConfigMap]: { code: T, value: ConfigMap[T] };
+}[keyof ConfigMap];
+
+export {
+    CONFIG_NAME, LOCAL_STORAGE_KEY,
+};
+export type {
+    ConfigMap, ConfigUpdate,
+};

--- a/new-log-viewer/src/typings/config.ts
+++ b/new-log-viewer/src/typings/config.ts
@@ -7,7 +7,7 @@ enum THEME_NAME {
     LIGHT = "light",
 }
 
-enum CONFIG_CODE {
+enum CONFIG_KEY {
     DECODER_OPTIONS = "decoderOptions",
     THEME = "theme",
     PAGE_SIZE = "pageSize",
@@ -15,29 +15,29 @@ enum CONFIG_CODE {
 
 /* eslint-disable @typescript-eslint/prefer-literal-enum-member */
 enum LOCAL_STORAGE_KEY {
-    DECODER_OPTIONS_FORMAT_STRING = `${CONFIG_CODE.DECODER_OPTIONS}/formatString`,
-    DECODER_OPTIONS_LOG_LEVEL_KEY = `${CONFIG_CODE.DECODER_OPTIONS}/logLevelKey`,
-    DECODER_OPTIONS_TIMESTAMP_KEY = `${CONFIG_CODE.DECODER_OPTIONS}/timestampKey`,
-    THEME = CONFIG_CODE.THEME,
-    PAGE_SIZE = CONFIG_CODE.PAGE_SIZE,
+    DECODER_OPTIONS_FORMAT_STRING = `${CONFIG_KEY.DECODER_OPTIONS}/formatString`,
+    DECODER_OPTIONS_LOG_LEVEL_KEY = `${CONFIG_KEY.DECODER_OPTIONS}/logLevelKey`,
+    DECODER_OPTIONS_TIMESTAMP_KEY = `${CONFIG_KEY.DECODER_OPTIONS}/timestampKey`,
+    THEME = CONFIG_KEY.THEME,
+    PAGE_SIZE = CONFIG_KEY.PAGE_SIZE,
 }
 /* eslint-enable @typescript-eslint/prefer-literal-enum-member */
 
 type ConfigMap = {
-    [CONFIG_CODE.DECODER_OPTIONS]: JsonlDecoderOptionsType,
-    [CONFIG_CODE.THEME]: THEME_NAME,
-    [CONFIG_CODE.PAGE_SIZE]: number,
+    [CONFIG_KEY.DECODER_OPTIONS]: JsonlDecoderOptionsType,
+    [CONFIG_KEY.THEME]: THEME_NAME,
+    [CONFIG_KEY.PAGE_SIZE]: number,
 };
 
 type ConfigUpdate = {
     [T in keyof ConfigMap]: {
-        code: T;
+        key: T;
         value: ConfigMap[T];
     }
 }[keyof ConfigMap];
 
 export {
-    CONFIG_CODE,
+    CONFIG_KEY,
     LOCAL_STORAGE_KEY,
     THEME_NAME,
 };

--- a/new-log-viewer/src/typings/config.ts
+++ b/new-log-viewer/src/typings/config.ts
@@ -22,13 +22,15 @@ type ConfigMap = {
     [CONFIG_NAME.PAGE_SIZE]: number,
 }
 
+type ConfigValueType<T extends CONFIG_NAME>= { code: T, value: ConfigMap[T] | null};
+
 type ConfigUpdate = {
-    [T in keyof ConfigMap]: { code: T, value: ConfigMap[T] };
+    [T in keyof ConfigMap]: ConfigValueType<T>;
 }[keyof ConfigMap];
 
 export {
     CONFIG_NAME, LOCAL_STORAGE_KEY,
 };
 export type {
-    ConfigMap, ConfigUpdate,
+    ConfigMap, ConfigUpdate, ConfigValueType,
 };

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -4,19 +4,14 @@ import {
     ConfigMap,
     ConfigUpdate,
     LOCAL_STORAGE_KEY,
+    THEME_NAME,
 } from "../typings/config";
 
-
-enum THEME {
-    SYSTEM = "system",
-    DARK = "dark",
-    LIGHT = "light",
-}
 
 const MAX_PAGE_SIZE = 1_000_000;
 
 /**
- *
+ * The default configuration values.
  */
 const CONFIG_DEFAULT: ConfigMap = Object.freeze({
     [CONFIG_CODE.DECODER_OPTIONS]: {
@@ -24,7 +19,7 @@ const CONFIG_DEFAULT: ConfigMap = Object.freeze({
         logLevelKey: "log.level",
         timestampKey: "@timestamp",
     },
-    [CONFIG_CODE.THEME]: THEME.SYSTEM,
+    [CONFIG_CODE.THEME]: THEME_NAME.SYSTEM,
     [CONFIG_CODE.PAGE_SIZE]: 10_000,
 });
 
@@ -40,7 +35,7 @@ const testConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
     let result = null;
     switch (code) {
         case CONFIG_CODE.THEME:
-            if (false === (Object.values(THEME) as string[]).includes(value)) {
+            if (false === (Object.values(THEME_NAME)).includes(value)) {
                 result = "Invalid theme name.";
             }
             break;

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -29,12 +29,12 @@ const CONFIG_DEFAULT: ConfigMap = Object.freeze({
 });
 
 /**
- * Validates the configuration updates based on the provided configuration updates.
+ * Validates the configuration value based on the provided code and value.
  *
- * @param props The configuration updates containing the code and value to be validated.
+ * @param props The code and value to be validated.
  * @param props.code
  * @param props.value
- * @return A result message indicating any validation errors, or an empty string if no errors.
+ * @return Null if the value is valid, otherwise returns an error message.
  */
 const testConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
     let result = null;
@@ -57,11 +57,12 @@ const testConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
 
 
 /**
- * Updates the configuration value in local storage based on the provided configuration updates.
+ * Updates the configuration value based on the provided code and value.
  *
- * @param props The configuration updates containing the code and value to be set.
+ * @param props The code and value to be updated.
  * @param props.code
  * @param props.value
+ * @return Null if the update succeeds, otherwise returns an error message.
  */
 const setConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
     const error = testConfig({code, value} as ConfigUpdate);
@@ -99,10 +100,10 @@ const setConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
 };
 
 /**
- * Retrieves the configuration value from local storage based on the provided configuration name.
+ * Retrieves the configuration value for the specified code.
  *
- * @param code The configuration name to retrieve the value for.
- * @return The configuration value or null if not found.
+ * @param code The code representing the configuration to retrieve.
+ * @return The value.
  */
 const getConfig = <T extends CONFIG_CODE>(code: T): ConfigMap[T] => {
     let value = null;

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -130,7 +130,7 @@ const getConfig = <T extends CONFIG_CODE>(code: T): ConfigMap[T] => {
 
     // Fallback to default values if the config is absent from `localStorage`.
     if (null === value ||
-        ("object" === typeof value && Object.values(value as object).includes(null))) {
+        ("object" === typeof value && Object.values(value).includes(null))) {
         value = CONFIG_DEFAULT[code];
         setConfig({code, value} as ConfigUpdate);
     }

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -121,7 +121,7 @@ const getConfig = <T extends CONFIG_CODE>(code: T): ConfigMap[T] => {
                 timestampKey: window.localStorage.getItem(
                     LOCAL_STORAGE_KEY.DECODER_OPTIONS_TIMESTAMP_KEY
                 ),
-            };
+            } as DecoderOptionsType;
             break;
         case CONFIG_CODE.THEME: {
             value = window.localStorage.getItem(LOCAL_STORAGE_KEY.THEME);

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -4,27 +4,14 @@ import {
     ConfigUpdate,
     LOCAL_STORAGE_KEY,
 } from "../typings/config";
-import {
-    WORKER_RESP_CODE,
-    WorkerResp,
-} from "../typings/worker";
 
 
 /**
+ * Retrieves the configuration value from local storage based on the provided configuration name.
  *
- * @param code
- * @param args
- */
-const postResp = <T extends WORKER_RESP_CODE>(
-    code: T,
-    args: WorkerResp<T>
-) => {
-    postMessage({code, args});
-};
-
-/**
- *
- * @param code
+ * @template T - The type of the configuration name.
+ * @param code The configuration name to retrieve the value for.
+ * @return - The configuration value or null if not found.
  */
 const getConfig = <T extends CONFIG_NAME>(code: T): ConfigMap[T] | null => {
     switch (code) {
@@ -49,8 +36,9 @@ const getConfig = <T extends CONFIG_NAME>(code: T): ConfigMap[T] | null => {
 };
 
 /**
+ * Updates the configuration value in local storage based on the provided configuration updates.
  *
- * @param configUpdates
+ * @param configUpdates The configuration updates containing the code and value to be set.
  */
 const setConfig = (configUpdates: ConfigUpdate) => {
     const {code, value} = configUpdates;

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -34,6 +34,11 @@ const CONFIG_DEFAULT: ConfigMap = Object.freeze({
 const testConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
     let result = null;
     switch (code) {
+        case CONFIG_CODE.DECODER_OPTIONS:
+            if (Object.values(value).includes("")) {
+                result = "Decoder options cannot be empty.";
+            }
+            break;
         case CONFIG_CODE.THEME:
             if (false === (Object.values(THEME_NAME)).includes(value)) {
                 result = "Invalid theme name.";

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -45,8 +45,8 @@ const testConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
             }
             break;
         case CONFIG_CODE.PAGE_SIZE:
-            if (MAX_PAGE_SIZE < value || 0 >= value) {
-                result = "Invalid page size.";
+            if (0 >= value || MAX_PAGE_SIZE < value) {
+                result = `Page size must be greater than 0 and not exceed ${MAX_PAGE_SIZE}.`;
             }
             break;
         default: break;

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -24,12 +24,12 @@ const CONFIG_DEFAULT: ConfigMap = Object.freeze({
 });
 
 /**
- * Validates the configuration value based on the provided code and value.
+ * Validates the config denoted by the given code and value.
  *
- * @param props The code and value to be validated.
+ * @param props
  * @param props.code
  * @param props.value
- * @return Null if the value is valid, otherwise returns an error message.
+ * @return `null` if the value is valid, or an error message otherwise.
  */
 const testConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
     let result = null;
@@ -46,7 +46,7 @@ const testConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
             break;
         case CONFIG_CODE.PAGE_SIZE:
             if (0 >= value || MAX_PAGE_SIZE < value) {
-                result = `Page size must be greater than 0 and not exceed ${MAX_PAGE_SIZE}.`;
+                result = `Page size must be greater than 0 and less than ${MAX_PAGE_SIZE + 1}.`;
             }
             break;
         default: break;
@@ -57,12 +57,12 @@ const testConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
 
 
 /**
- * Updates the configuration value based on the provided code and value.
+ * Updates the config denoted by the given code and value.
  *
- * @param props The code and value to be updated.
+ * @param props
  * @param props.code
  * @param props.value
- * @return Null if the update succeeds, otherwise returns an error message.
+ * @return `null` if the update succeeds, or an error message otherwise.
  */
 const setConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
     const error = testConfig({code, value} as ConfigUpdate);
@@ -100,9 +100,9 @@ const setConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
 };
 
 /**
- * Retrieves the configuration value for the specified code.
+ * Retrieves the config value for the specified code.
  *
- * @param code The code representing the configuration to retrieve.
+ * @param code
  * @return The value.
  */
 const getConfig = <T extends CONFIG_CODE>(code: T): ConfigMap[T] => {

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -1,11 +1,12 @@
 import {Nullable} from "../typings/common";
 import {
-    CONFIG_CODE,
+    CONFIG_KEY,
     ConfigMap,
     ConfigUpdate,
     LOCAL_STORAGE_KEY,
     THEME_NAME,
 } from "../typings/config";
+import {DecoderOptionsType} from "../typings/decoders";
 
 
 const MAX_PAGE_SIZE = 1_000_000;
@@ -14,37 +15,37 @@ const MAX_PAGE_SIZE = 1_000_000;
  * The default configuration values.
  */
 const CONFIG_DEFAULT: ConfigMap = Object.freeze({
-    [CONFIG_CODE.DECODER_OPTIONS]: {
+    [CONFIG_KEY.DECODER_OPTIONS]: {
         formatString: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%process.thread.name] %log.level %message%n",
         logLevelKey: "log.level",
         timestampKey: "@timestamp",
     },
-    [CONFIG_CODE.THEME]: THEME_NAME.SYSTEM,
-    [CONFIG_CODE.PAGE_SIZE]: 10_000,
+    [CONFIG_KEY.THEME]: THEME_NAME.SYSTEM,
+    [CONFIG_KEY.PAGE_SIZE]: 10_000,
 });
 
 /**
- * Validates the config denoted by the given code and value.
+ * Validates the config denoted by the given key and value.
  *
  * @param props
- * @param props.code
+ * @param props.key
  * @param props.value
  * @return `null` if the value is valid, or an error message otherwise.
  */
-const testConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
+const testConfig = ({key, value}: ConfigUpdate): Nullable<string> => {
     let result = null;
-    switch (code) {
-        case CONFIG_CODE.DECODER_OPTIONS:
+    switch (key) {
+        case CONFIG_KEY.DECODER_OPTIONS:
             if (Object.values(value).includes("")) {
                 result = "Decoder options cannot be empty.";
             }
             break;
-        case CONFIG_CODE.THEME:
+        case CONFIG_KEY.THEME:
             if (false === (Object.values(THEME_NAME)).includes(value)) {
                 result = "Invalid theme name.";
             }
             break;
-        case CONFIG_CODE.PAGE_SIZE:
+        case CONFIG_KEY.PAGE_SIZE:
             if (0 >= value || MAX_PAGE_SIZE < value) {
                 result = `Page size must be greater than 0 and less than ${MAX_PAGE_SIZE + 1}.`;
             }
@@ -57,23 +58,23 @@ const testConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
 
 
 /**
- * Updates the config denoted by the given code and value.
+ * Updates the config denoted by the given key and value.
  *
  * @param props
- * @param props.code
+ * @param props.key
  * @param props.value
  * @return `null` if the update succeeds, or an error message otherwise.
  */
-const setConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
-    const error = testConfig({code, value} as ConfigUpdate);
+const setConfig = ({key, value}: ConfigUpdate): Nullable<string> => {
+    const error = testConfig({key, value} as ConfigUpdate);
     if (null !== error) {
-        console.error(`Unable to set ${code}=${JSON.stringify(value)}: ${error}`);
+        console.error(`Unable to set ${key}=${JSON.stringify(value)}: ${error}`);
 
         return error;
     }
 
-    switch (code) {
-        case CONFIG_CODE.DECODER_OPTIONS:
+    switch (key) {
+        case CONFIG_KEY.DECODER_OPTIONS:
             window.localStorage.setItem(
                 LOCAL_STORAGE_KEY.DECODER_OPTIONS_FORMAT_STRING,
                 value.formatString
@@ -87,10 +88,10 @@ const setConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
                 value.timestampKey
             );
             break;
-        case CONFIG_CODE.THEME:
+        case CONFIG_KEY.THEME:
             window.localStorage.setItem(LOCAL_STORAGE_KEY.THEME, value);
             break;
-        case CONFIG_CODE.PAGE_SIZE:
+        case CONFIG_KEY.PAGE_SIZE:
             window.localStorage.setItem(LOCAL_STORAGE_KEY.PAGE_SIZE, value.toString());
             break;
         default: break;
@@ -100,17 +101,17 @@ const setConfig = ({code, value}: ConfigUpdate): Nullable<string> => {
 };
 
 /**
- * Retrieves the config value for the specified code.
+ * Retrieves the config value for the specified key.
  *
- * @param code
+ * @param key
  * @return The value.
  */
-const getConfig = <T extends CONFIG_CODE>(code: T): ConfigMap[T] => {
+const getConfig = <T extends CONFIG_KEY>(key: T): ConfigMap[T] => {
     let value = null;
 
     // Read values from `localStorage`.
-    switch (code) {
-        case CONFIG_CODE.DECODER_OPTIONS:
+    switch (key) {
+        case CONFIG_KEY.DECODER_OPTIONS:
             value = {
                 formatString: window.localStorage.getItem(
                     LOCAL_STORAGE_KEY.DECODER_OPTIONS_FORMAT_STRING
@@ -123,11 +124,11 @@ const getConfig = <T extends CONFIG_CODE>(code: T): ConfigMap[T] => {
                 ),
             } as DecoderOptionsType;
             break;
-        case CONFIG_CODE.THEME: {
+        case CONFIG_KEY.THEME: {
             value = window.localStorage.getItem(LOCAL_STORAGE_KEY.THEME);
             break;
         }
-        case CONFIG_CODE.PAGE_SIZE:
+        case CONFIG_KEY.PAGE_SIZE:
             value = window.localStorage.getItem(LOCAL_STORAGE_KEY.PAGE_SIZE);
             break;
         default: break;
@@ -136,13 +137,13 @@ const getConfig = <T extends CONFIG_CODE>(code: T): ConfigMap[T] => {
     // Fallback to default values if the config is absent from `localStorage`.
     if (null === value ||
         ("object" === typeof value && Object.values(value).includes(null))) {
-        value = CONFIG_DEFAULT[code];
-        setConfig({code, value} as ConfigUpdate);
+        value = CONFIG_DEFAULT[key];
+        setConfig({key, value} as ConfigUpdate);
     }
 
     // Process values read from `localStorage`.
-    switch (code) {
-        case CONFIG_CODE.PAGE_SIZE:
+    switch (key) {
+        case CONFIG_KEY.PAGE_SIZE:
             value = Number(value);
             break;
         default: break;

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -1,0 +1,80 @@
+import {
+    CONFIG_NAME,
+    ConfigMap,
+    ConfigUpdate,
+    LOCAL_STORAGE_KEY,
+} from "../typings/config";
+import {
+    WORKER_RESP_CODE,
+    WorkerResp,
+} from "../typings/worker";
+
+
+/**
+ *
+ * @param code
+ * @param args
+ */
+const postResp = <T extends WORKER_RESP_CODE>(
+    code: T,
+    args: WorkerResp<T>
+) => {
+    postMessage({code, args});
+};
+
+/**
+ *
+ * @param code
+ */
+const getConfig = <T extends CONFIG_NAME>(code: T): ConfigMap[T] | null => {
+    switch (code) {
+        case CONFIG_NAME.DECODER_OPTIONS:
+            return {
+                formatString: window.localStorage.getItem(
+                    LOCAL_STORAGE_KEY.DECODER_OPTIONS_FORMAT_STRING
+                ),
+                logLevelKey: window.localStorage.getItem(
+                    LOCAL_STORAGE_KEY.DECODER_OPTIONS_LOG_LEVEL_KEY
+                ),
+                timestampKey: window.localStorage.getItem(
+                    LOCAL_STORAGE_KEY.DECODER_OPTIONS_TIMESTAMP_KEY
+                ),
+            } as ConfigMap[T];
+        case CONFIG_NAME.THEME:
+            return window.localStorage.getItem(LOCAL_STORAGE_KEY.THEME) as ConfigMap[T];
+        case CONFIG_NAME.PAGE_SIZE:
+            return window.localStorage.getItem(LOCAL_STORAGE_KEY.PAGE_SIZE) as ConfigMap[T];
+        default: return null;
+    }
+};
+
+/**
+ *
+ * @param configUpdates
+ */
+const setConfig = (configUpdates: ConfigUpdate) => {
+    const {code, value} = configUpdates;
+    switch (code) {
+        case CONFIG_NAME.DECODER_OPTIONS:
+            window.localStorage.setItem(
+                LOCAL_STORAGE_KEY.DECODER_OPTIONS_FORMAT_STRING,
+                value.formatString
+            );
+            window.localStorage.setItem(
+                LOCAL_STORAGE_KEY.DECODER_OPTIONS_LOG_LEVEL_KEY,
+                value.logLevelKey
+            );
+            window.localStorage.setItem(
+                LOCAL_STORAGE_KEY.DECODER_OPTIONS_TIMESTAMP_KEY,
+                value.timestampKey
+            );
+            break;
+        case CONFIG_NAME.THEME:
+            window.localStorage.setItem(LOCAL_STORAGE_KEY.THEME, value);
+            break;
+        case CONFIG_NAME.PAGE_SIZE:
+            window.localStorage.setItem(LOCAL_STORAGE_KEY.PAGE_SIZE, value.toString());
+            break;
+        default: break;
+    }
+};

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -152,7 +152,6 @@ const getConfig = <T extends CONFIG_CODE>(code: T): ConfigMap[T] => {
 };
 
 export {
-    CONFIG_DEFAULT,
     getConfig,
     setConfig,
     testConfig,


### PR DESCRIPTION
# References
This PR follows #48.

# Description
The new `utils/config.ts` provides 3 functions:
- `getConfig` - takes in a `CONFIG_NAME` (defined in `typings/config.ts`) and returns the corresponding result defined in `ConfigMap`. If the code is invalid, return `null`.
- `testConfig` - validate a `ConfigUpdate` object (essentially a {code, value} pair). It is provided to users to test their configs, and is also used by `setConfig` to endorse inputs.
- `setConfig` - takes in a `ConfigUpdate` object, validate the input using `testConfig`, and store to localStorage.

# Validation performed

