### PR TITLE
new-log-viewer: LogbackFormatter: Only insert timestamp if date pattern was specified.

### DIFF
--- a/new-log-viewer/src/services/formatters/LogbackFormatter.ts
+++ b/new-log-viewer/src/services/formatters/LogbackFormatter.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 
+import {Nullable} from "../../typings/common";
 import {
     Formatter,
     FormatterOptionsType,
@@ -34,7 +35,7 @@ const convertDateTimeFormatterPatternToDayJs = (pattern: string): string => {
 class LogbackFormatter implements Formatter {
     #formatString: string;
 
-    #datePattern: string = "";
+    #datePattern: Nullable<string> = null;
 
     #dateFormat: string = "";
 
@@ -135,6 +136,10 @@ class LogbackFormatter implements Formatter {
      * @return The formatted string.
      */
     #formatTimestamp (timestamp: dayjs.Dayjs, formatString: string): string {
+        if (null === this.#datePattern) {
+            return formatString;
+        }
+
         const formattedDate = timestamp.format(this.#dateFormat);
         formatString = formatString.replace(this.#datePattern, formattedDate);
 


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#46 added support for decoding JSONL files. One issue was found that when the "formatString" does not include a date pattern, the formatted message still include formatted dates.

# Description
1. Do not format date if no date pattern is specified in configured format string.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Loaded Log Viewer with example jsonl file.
   ![image](https://github.com/user-attachments/assets/44d15e91-ed5d-44cb-bc49-46d53e8da48b)
   **Screenshot showing the formatted messages with dates**
2. In config debug form, configured `decoderOptions/formatString` with value `[%process.thread.name] %log.level %message%n`, which is the default with the date pattern `%d{yyyy-MM-dd HH:mm:ss.SSS}` removed from the beginning.
3. Applied the config. After the page was reloaded, observed that the formatted messages no longer includes dates.
   ![image](https://github.com/user-attachments/assets/3bd95c5f-8d48-49b8-b42b-b5b7fd45f1cb)
   **Screenshot showing the formatted messages do not include dates because now no such is configured in decoderOptions/formatString**