### PR TITLE
new-log-viewer: Avoid redundant `loadPage` after `loadFile` when loading a URL with a `logEventNum` specified.

### DIFF
--- a/new-log-viewer/src/contexts/StateContextProvider.tsx
+++ b/new-log-viewer/src/contexts/StateContextProvider.tsx
@@ -51,7 +51,7 @@ const STATE_DEFAULT = Object.freeze({
     logData: "Loading...",
     numEvents: 0,
     numPages: 0,
-    pageNum: null,
+    pageNum: 0,
 });
 
 interface StateContextProviderProps {
@@ -193,18 +193,20 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
             numPagesRef.current
         );
 
-        if (newPageNum === pageNumRef.current) {
-            // Don't need to switch pages so just update `logEventNum` in the URL.
-            updateLogEventNumInUrl(numEvents, logEventNumRef.current);
-        } else if (STATE_DEFAULT.pageNum !== pageNumRef.current) {
-            // This is not the initial page load, so request a page switch.
-            // NOTE: We don't need to call `updateLogEventNumInUrl()` since it's called when
-            // handling the `WORKER_RESP_CODE.PAGE_DATA` response (the response to
-            // `WORKER_REQ_CODE.LOAD_PAGE` requests) .
-            mainWorkerPostReq(WORKER_REQ_CODE.LOAD_PAGE, {
-                cursor: {code: CURSOR_CODE.PAGE_NUM, args: {pageNum: newPageNum}},
-                decoderOptions: getConfig(CONFIG_KEY.DECODER_OPTIONS),
-            });
+        if (STATE_DEFAULT.pageNum !== pageNumRef.current) {
+            if (newPageNum === pageNumRef.current) {
+                // Don't need to switch pages so just update `logEventNum` in the URL.
+                updateLogEventNumInUrl(numEvents, logEventNumRef.current);
+            } else {
+                // This is not the initial page load, so request a page switch.
+                // NOTE: We don't need to call `updateLogEventNumInUrl()` since it's called when
+                // handling the `WORKER_RESP_CODE.PAGE_DATA` response (the response to
+                // `WORKER_REQ_CODE.LOAD_PAGE` requests) .
+                mainWorkerPostReq(WORKER_REQ_CODE.LOAD_PAGE, {
+                    cursor: {code: CURSOR_CODE.PAGE_NUM, args: {pageNum: newPageNum}},
+                    decoderOptions: getConfig(CONFIG_KEY.DECODER_OPTIONS),
+                });
+            }
         }
 
         pageNumRef.current = newPageNum;

--- a/new-log-viewer/src/contexts/StateContextProvider.tsx
+++ b/new-log-viewer/src/contexts/StateContextProvider.tsx
@@ -193,12 +193,11 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
             numPagesRef.current
         );
 
-        if (STATE_DEFAULT.pageNum === pageNumRef.current) {
-            return;
-        } else if (newPageNum === pageNumRef.current) {
-            // Don't need to switch pages so just update `logEventNum` in the URL.
-            updateLogEventNumInUrl(numEvents, logEventNumRef.current);
-        } else {
+        if (STATE_DEFAULT.pageNum !== pageNumRef.current) {
+            if (newPageNum === pageNumRef.current) {
+                // Don't need to switch pages so just update `logEventNum` in the URL.
+                updateLogEventNumInUrl(numEvents, logEventNumRef.current);
+            } else {
                 // This is not the initial page load, so request a page switch.
                 // NOTE: We don't need to call `updateLogEventNumInUrl()` since it's called when
                 // handling the `WORKER_RESP_CODE.PAGE_DATA` response (the response to

--- a/new-log-viewer/src/contexts/StateContextProvider.tsx
+++ b/new-log-viewer/src/contexts/StateContextProvider.tsx
@@ -193,11 +193,12 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
             numPagesRef.current
         );
 
-        if (STATE_DEFAULT.pageNum !== pageNumRef.current) {
-            if (newPageNum === pageNumRef.current) {
-                // Don't need to switch pages so just update `logEventNum` in the URL.
-                updateLogEventNumInUrl(numEvents, logEventNumRef.current);
-            } else {
+        if (STATE_DEFAULT.pageNum === pageNumRef.current) {
+            return;
+        } else if (newPageNum === pageNumRef.current) {
+            // Don't need to switch pages so just update `logEventNum` in the URL.
+            updateLogEventNumInUrl(numEvents, logEventNumRef.current);
+        } else {
                 // This is not the initial page load, so request a page switch.
                 // NOTE: We don't need to call `updateLogEventNumInUrl()` since it's called when
                 // handling the `WORKER_RESP_CODE.PAGE_DATA` response (the response to

--- a/new-log-viewer/src/contexts/StateContextProvider.tsx
+++ b/new-log-viewer/src/contexts/StateContextProvider.tsx
@@ -193,12 +193,12 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
             numPagesRef.current
         );
 
+        // Request a page switch only if it's not the initial page load.
         if (STATE_DEFAULT.pageNum !== pageNumRef.current) {
             if (newPageNum === pageNumRef.current) {
                 // Don't need to switch pages so just update `logEventNum` in the URL.
                 updateLogEventNumInUrl(numEvents, logEventNumRef.current);
             } else {
-                // This is not the initial page load, so request a page switch.
                 // NOTE: We don't need to call `updateLogEventNumInUrl()` since it's called when
                 // handling the `WORKER_RESP_CODE.PAGE_DATA` response (the response to
                 // `WORKER_REQ_CODE.LOAD_PAGE` requests) .


### PR DESCRIPTION
# References
new-log-viewer series: #45 #46 #48 #51 #52 #53

#48 `new-log-viewer: Add UrlContextProvider to provide URL parameters and use them in the StateContextProvider.`

It was found that when `logEventNum` is specified in the web application URL, a redundant `loadPage` request is sent to the main service worker after an initial `loadFile` request.

![image](https://github.com/user-attachments/assets/37c89edd-9d03-4b41-8e50-4af0575c61b9)
**Debug prints which show a redundant `loadPage` request is sent after `loadFile`**

# Description
1. new-log-viewer: Avoid redundant `loadPage` after `loadFile` when `logEventNum` is specified in the URL.

# Validation performed
1. Referred to the validation steps in #46 to start the debug server.
2. Loaded http://localhost:3010/?filePath=http://localhost:3010/test/example.jsonl#logEventNum=10 and observed no `loadPage` request is sent after `loadFile`.
   ![image](https://github.com/user-attachments/assets/beb29120-97f2-4af8-b7d6-ea0b29e5a843)
   **Screenshot showing no `loadPage` request is sent after `loadFile`**
