### PR TITLE
new-log-viewer: Add support for loading files through open dialog or drag-and-drop; Display file name in the UI.

### DIFF
--- a/new-log-viewer/public/index.html
+++ b/new-log-viewer/public/index.html
@@ -7,6 +7,9 @@
     <meta name="keywords"
           content="yscope clp debug debugging large log logs s3 scanner viewer vscode">
     <meta name="viewport" content="initial-scale=1, maximum-scale=1">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" crossorigin href="https://fonts.gstatic.com">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
 </head>
 <body>
 <div id="root"></div>

--- a/new-log-viewer/src/components/DropFileContainer/index.css
+++ b/new-log-viewer/src/components/DropFileContainer/index.css
@@ -1,0 +1,31 @@
+.drop-file-container {
+    width: 100%;
+    height: 100%;
+    position: relative;
+}
+
+.drop-file-children {
+    width: 100%;
+    height: 100%;
+}
+
+.hover-mask {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(2, 88, 168, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+}
+
+.hover-message {
+    padding: 8px;
+    color: #616161;
+    font-size: 14px;
+    font-family: Roboto, sans-serif;
+    background-color: #f3f3f3;
+    z-index: 11;
+}

--- a/new-log-viewer/src/components/DropFileContainer/index.css
+++ b/new-log-viewer/src/components/DropFileContainer/index.css
@@ -24,7 +24,7 @@
 .hover-message {
     padding: 8px;
     color: #616161;
-    font-size: 14px;
+    font-size: 0.875rem;
     font-family: Roboto, sans-serif;
     background-color: #f3f3f3;
     z-index: var(--drop-file-container-hover-message-z-index);

--- a/new-log-viewer/src/components/DropFileContainer/index.css
+++ b/new-log-viewer/src/components/DropFileContainer/index.css
@@ -18,7 +18,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: var(--drop-file-container-hover-mask-z-index);
+    z-index: var(--ylv-drop-file-container-hover-mask-z-index);
 }
 
 .hover-message {
@@ -27,5 +27,5 @@
     font-size: 0.875rem;
     font-family: Roboto, sans-serif;
     background-color: #f3f3f3;
-    z-index: var(--drop-file-container-hover-message-z-index);
+    z-index: var(--ylv-drop-file-container-hover-message-z-index);
 }

--- a/new-log-viewer/src/components/DropFileContainer/index.css
+++ b/new-log-viewer/src/components/DropFileContainer/index.css
@@ -25,7 +25,7 @@
     padding: 8px;
     color: #616161;
     font-size: 0.875rem;
-    font-family: Roboto, sans-serif;
+    font-family: var(--ylv-ui-font-family), sans-serif;
     background-color: #f3f3f3;
     z-index: var(--ylv-drop-file-container-hover-message-z-index);
 }

--- a/new-log-viewer/src/components/DropFileContainer/index.css
+++ b/new-log-viewer/src/components/DropFileContainer/index.css
@@ -18,7 +18,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 10;
+    z-index: var(--drop-file-container-hover-mask-z-index);
 }
 
 .hover-message {
@@ -27,5 +27,5 @@
     font-size: 14px;
     font-family: Roboto, sans-serif;
     background-color: #f3f3f3;
-    z-index: 11;
+    z-index: var(--drop-file-container-hover-message-z-index);
 }

--- a/new-log-viewer/src/components/DropFileContainer/index.tsx
+++ b/new-log-viewer/src/components/DropFileContainer/index.tsx
@@ -65,9 +65,7 @@ const DropFileContainer = ({children}: DropFileContextProviderProps) => {
             onDrop={handleDrop}
         >
             <div
-                className={`drop-file-children ${isFileHovering ?
-                    "drop-file-children-no-pointer-events" :
-                    ""}`}
+                className={"drop-file-children"}
                 onDrop={handleDrop}
             >
                 {children}

--- a/new-log-viewer/src/components/DropFileContainer/index.tsx
+++ b/new-log-viewer/src/components/DropFileContainer/index.tsx
@@ -24,11 +24,6 @@ const DropFileContainer = ({children}: DropFileContextProviderProps) => {
     const {loadFile} = useContext(StateContext);
     const [isFileHovering, setIsFileHovering] = useState(false);
 
-    /**
-     * Handler for a drag event.
-     *
-     * @param ev
-     */
     const handleDrag = (ev: React.DragEvent<HTMLDivElement>) => {
         ev.preventDefault();
         ev.stopPropagation();
@@ -46,12 +41,6 @@ const DropFileContainer = ({children}: DropFileContextProviderProps) => {
         }
     };
 
-    /**
-     * Handler for a drop event. handleFileDrop callback is used
-     * to load the dropped file into the viewer.
-     *
-     * @param ev
-     */
     const handleDrop = (ev: React.DragEvent<HTMLDivElement>) => {
         ev.preventDefault();
         ev.stopPropagation();

--- a/new-log-viewer/src/components/DropFileContainer/index.tsx
+++ b/new-log-viewer/src/components/DropFileContainer/index.tsx
@@ -60,7 +60,7 @@ const DropFileContainer = ({children}: DropFileContextProviderProps) => {
 
         const [file] = ev.dataTransfer.files;
         if ("undefined" === typeof file) {
-            console.warn("No file is getting dropped");
+            console.warn("No file dropped.");
 
             return;
         }
@@ -91,7 +91,7 @@ const DropFileContainer = ({children}: DropFileContextProviderProps) => {
                             className={"hover-message"}
                             onDrop={handleDrop}
                         >
-                            Drop File to View
+                            Drop file to view
                         </div>
                     </div>
                 )}

--- a/new-log-viewer/src/components/DropFileContainer/index.tsx
+++ b/new-log-viewer/src/components/DropFileContainer/index.tsx
@@ -31,10 +31,12 @@ const DropFileContainer = ({children}: DropFileContextProviderProps) => {
         if ("dragenter" === ev.type) {
             setIsFileHovering(true);
         } else if ("dragleave" === ev.type) {
-            // "dragleave" could get fired when the wrapped `children` receives focus.
-            // Setting `pointer-events: none` on the children is viable but could cause the
-            // children to be non-responsive. Instead, check if the pointer is still within the
-            // range of the DropFileContainer; if so, deem the file is still hovering.
+            // Only stop the hover effect if the pointer leaves the bounding rectangle of the
+            // DropFileContainer.
+            //
+            // NOTE: "dragleave" could get fired when the wrapped `children` receive focus. Setting
+            // `pointer-events: none` on the children is viable but could cause the children to be
+            // unresponsive. So instead, we use the solution below.
             const {bottom, left, right, top} = ev.currentTarget.getBoundingClientRect();
             if (ev.clientX >= left && ev.clientX <= right &&
                 ev.clientY >= top && ev.clientY <= bottom) {

--- a/new-log-viewer/src/components/DropFileContainer/index.tsx
+++ b/new-log-viewer/src/components/DropFileContainer/index.tsx
@@ -31,6 +31,10 @@ const DropFileContainer = ({children}: DropFileContextProviderProps) => {
         if ("dragenter" === ev.type) {
             setIsFileHovering(true);
         } else if ("dragleave" === ev.type) {
+            // "dragleave" could get fired when the wrapped `children` receives focus.
+            // Setting `pointer-events: none` on the children is viable but could cause the
+            // children to be non-responsive. Instead, check if the pointer is still within the
+            // range of the DropFileContainer; if so, deem the file is still hovering.
             const {bottom, left, right, top} = ev.currentTarget.getBoundingClientRect();
             if (ev.clientX >= left && ev.clientX <= right &&
                 ev.clientY >= top && ev.clientY <= bottom) {

--- a/new-log-viewer/src/components/Layout.tsx
+++ b/new-log-viewer/src/components/Layout.tsx
@@ -11,10 +11,12 @@ import {
     LOCAL_STORAGE_KEY,
     THEME_NAME,
 } from "../typings/config";
+import {CURSOR_CODE} from "../typings/worker";
 import {
     getConfig,
     setConfig,
 } from "../utils/config";
+import {openFile} from "../utils/file";
 
 
 const formFields = [
@@ -141,8 +143,9 @@ const ConfigForm = () => {
 const Layout = () => {
     const {
         logData,
-        pageNum,
+        loadFile,
         numEvents,
+        pageNum,
     } = useContext(StateContext);
     const {logEventNum} = useContext(UrlContext);
 
@@ -152,6 +155,12 @@ const Layout = () => {
 
     const handleCopyLinkButtonClick = () => {
         copyPermalinkToClipboard({}, {logEventNum: numEvents});
+    };
+
+    const handleOpenFileButtonClick = () => {
+        openFile((file) => {
+            loadFile(file, {code: CURSOR_CODE.LAST_EVENT, args: null});
+        });
     };
 
     return (
@@ -175,6 +184,10 @@ const Layout = () => {
 
                 <button onClick={handleCopyLinkButtonClick}>
                     Copy link to last log
+                </button>
+
+                <button onClick={handleOpenFileButtonClick}>
+                    Open File
                 </button>
 
                 <ConfigForm/>

--- a/new-log-viewer/src/components/Layout.tsx
+++ b/new-log-viewer/src/components/Layout.tsx
@@ -142,6 +142,7 @@ const ConfigForm = () => {
  */
 const Layout = () => {
     const {
+        fileName,
         logData,
         loadFile,
         numEvents,
@@ -180,6 +181,10 @@ const Layout = () => {
                     PageNum -
                     {" "}
                     {pageNum}
+                    {" "}
+                    | FileName -
+                    {" "}
+                    {fileName}
                 </h3>
 
                 <button onClick={handleCopyLinkButtonClick}>

--- a/new-log-viewer/src/components/Layout.tsx
+++ b/new-log-viewer/src/components/Layout.tsx
@@ -30,6 +30,7 @@ import {
     getFirstItemNumInNextChunk,
     getLastItemNumInPrevChunk,
 } from "../utils/math";
+import DropFileContainer from "./DropFileContainer";
 import Editor from "./Editor";
 import {goToPositionAndCenter} from "./Editor/MonacoInstance/utils";
 
@@ -277,7 +278,9 @@ const Layout = () => {
 
                 <ConfigForm/>
                 <div style={{flexDirection: "column", flexGrow: 1}}>
-                    <Editor onCustomAction={handleCustomAction}/>
+                    <DropFileContainer>
+                        <Editor onCustomAction={handleCustomAction}/>
+                    </DropFileContainer>
                 </div>
             </div>
         </>

--- a/new-log-viewer/src/contexts/StateContextProvider.tsx
+++ b/new-log-viewer/src/contexts/StateContextProvider.tsx
@@ -9,6 +9,7 @@ import React, {
 
 import {Nullable} from "../typings/common";
 import {CONFIG_KEY} from "../typings/config";
+import {SEARCH_PARAM_NAMES} from "../typings/url";
 import {
     BeginLineNumToLogEventNumMap,
     CURSOR_CODE,
@@ -26,6 +27,7 @@ import {
 } from "../utils/math";
 import {
     updateWindowUrlHashParams,
+    updateWindowUrlSearchParams,
     URL_HASH_PARAMS_DEFAULT,
     URL_SEARCH_PARAMS_DEFAULT,
     UrlContext,
@@ -153,6 +155,9 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
     }, []);
 
     const loadFile = useCallback((fileSrc: FileSrcType, cursor: CursorType) => {
+        if ("string" !== typeof fileSrc) {
+            updateWindowUrlSearchParams({[SEARCH_PARAM_NAMES.FILE_PATH]: null});
+        }
         if (null !== mainWorkerRef.current) {
             mainWorkerRef.current.terminate();
         }

--- a/new-log-viewer/src/contexts/StateContextProvider.tsx
+++ b/new-log-viewer/src/contexts/StateContextProvider.tsx
@@ -9,7 +9,6 @@ import React, {
 
 import {Nullable} from "../typings/common";
 import {CONFIG_KEY} from "../typings/config";
-import {SEARCH_PARAM_NAMES} from "../typings/url";
 import {
     BeginLineNumToLogEventNumMap,
     CURSOR_CODE,
@@ -27,7 +26,6 @@ import {
 } from "../utils/math";
 import {
     updateWindowUrlHashParams,
-    updateWindowUrlSearchParams,
     URL_HASH_PARAMS_DEFAULT,
     URL_SEARCH_PARAMS_DEFAULT,
     UrlContext,
@@ -115,7 +113,6 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
     const [numEvents, setNumEvents] = useState<number>(STATE_DEFAULT.numEvents);
     const beginLineNumToLogEventNumRef =
         useRef<BeginLineNumToLogEventNumMap>(STATE_DEFAULT.beginLineNumToLogEventNum);
-    const filePathRef = useRef<Nullable<string>>(filePath);
     const logEventNumRef = useRef(logEventNum);
     const numPagesRef = useRef<number>(STATE_DEFAULT.numPages);
     const pageNumRef = useRef<Nullable<number>>(STATE_DEFAULT.pageNum);
@@ -136,7 +133,6 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
             case WORKER_RESP_CODE.LOG_FILE_INFO:
                 setFileName(args.fileName);
                 setNumEvents(args.numEvents);
-                updateWindowUrlSearchParams({[SEARCH_PARAM_NAMES.FILE_PATH]: filePathRef.current});
                 break;
             case WORKER_RESP_CODE.PAGE_DATA: {
                 setLogData(args.logs);
@@ -157,13 +153,6 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
     }, []);
 
     const loadFile = useCallback((fileSrc: FileSrcType, cursor: CursorType) => {
-        // Backup and unset `filePath` in the URL, which can be restored after successful loading
-        // (when `WORKER_RESP_CODE.LOG_FILE_INFO` is received) if `fileSrc` is a URL.
-        filePathRef.current = "string" === typeof fileSrc ?
-            fileSrc :
-            null;
-        updateWindowUrlSearchParams({[SEARCH_PARAM_NAMES.FILE_PATH]: null});
-
         if (null !== mainWorkerRef.current) {
             mainWorkerRef.current.terminate();
         }

--- a/new-log-viewer/src/index.css
+++ b/new-log-viewer/src/index.css
@@ -4,6 +4,10 @@ html, body, #root {
     width: 100%;
 }
 
+html {
+    font-size: 16px;
+}
+
 :root {
     /* font-family globals */
     --ylv-ui-font-family: -apple-system, BlinkMacSystemFont, system-ui, Ubuntu, "Droid Sans", Roboto;

--- a/new-log-viewer/src/index.css
+++ b/new-log-viewer/src/index.css
@@ -7,6 +7,6 @@ html, body, #root {
 :root {
     /* z-index values */
     /* .monaco-editor .minimap { z-index: 5; } */
-    --drop-file-container-hover-mask-z-index: 10;
-    --drop-file-container-hover-message-z-index: 11;
+    --ylv-drop-file-container-hover-mask-z-index: 10;
+    --ylv-drop-file-container-hover-message-z-index: 11;
 }

--- a/new-log-viewer/src/index.css
+++ b/new-log-viewer/src/index.css
@@ -13,8 +13,13 @@ html {
     --ylv-ui-font-family: -apple-system, BlinkMacSystemFont, system-ui, Ubuntu, "Droid Sans",
     Roboto;
 
-    /* z-index globals */
-    /* .monaco-editor .minimap { z-index: 5; } */
+    /* z-index globals
+     *
+     * Other z-index values in the project for reference:
+     * ```
+     * .monaco-editor .minimap { z-index: 5; }
+     * ```
+     */
     --ylv-drop-file-container-hover-mask-z-index: 10;
     --ylv-drop-file-container-hover-message-z-index: 11;
 }

--- a/new-log-viewer/src/index.css
+++ b/new-log-viewer/src/index.css
@@ -10,7 +10,8 @@ html {
 
 :root {
     /* font-family globals */
-    --ylv-ui-font-family: -apple-system, BlinkMacSystemFont, system-ui, Ubuntu, "Droid Sans", Roboto;
+    --ylv-ui-font-family: -apple-system, BlinkMacSystemFont, system-ui, Ubuntu, "Droid Sans",
+    Roboto;
 
     /* z-index globals */
     /* .monaco-editor .minimap { z-index: 5; } */

--- a/new-log-viewer/src/index.css
+++ b/new-log-viewer/src/index.css
@@ -3,3 +3,10 @@ html, body, #root {
     height: 100%;
     width: 100%;
 }
+
+:root {
+    /* z-index values */
+    /* .monaco-editor .minimap { z-index: 5; } */
+    --drop-file-container-hover-mask-z-index: 10;
+    --drop-file-container-hover-message-z-index: 11;
+}

--- a/new-log-viewer/src/index.css
+++ b/new-log-viewer/src/index.css
@@ -5,7 +5,10 @@ html, body, #root {
 }
 
 :root {
-    /* z-index values */
+    /* font-family globals */
+    --ylv-ui-font-family: -apple-system, BlinkMacSystemFont, system-ui, Ubuntu, "Droid Sans", Roboto;
+
+    /* z-index globals */
     /* .monaco-editor .minimap { z-index: 5; } */
     --ylv-drop-file-container-hover-mask-z-index: 10;
     --ylv-drop-file-container-hover-message-z-index: 11;

--- a/new-log-viewer/src/services/LogFileManager.ts
+++ b/new-log-viewer/src/services/LogFileManager.ts
@@ -21,7 +21,7 @@ import JsonlDecoder from "./decoders/JsonlDecoder";
  *
  * @param fileSrc The source of the file to load. This can be a string representing a URL, or a File
  * object.
- * @return A promise that resolves with the number of log events found in the file.
+ * @return A promise that resolves with an object containing the file name and file data.
  * @throws {Error} If the file source type is not supported.
  */
 const loadFile = async (fileSrc: FileSrcType)

--- a/new-log-viewer/src/services/LogFileManager.ts
+++ b/new-log-viewer/src/services/LogFileManager.ts
@@ -77,6 +77,10 @@ class LogFileManager {
         this.#decoder = this.#initDecoder(decoderOptions);
     }
 
+    get fileName () {
+        return this.#fileName;
+    }
+
     get numEvents () {
         return this.#numEvents;
     }

--- a/new-log-viewer/src/services/LogFileManager.ts
+++ b/new-log-viewer/src/services/LogFileManager.ts
@@ -32,8 +32,8 @@ const loadFile = async (fileSrc: FileSrcType)
         fileName = getBasenameFromUrlOrDefault(fileSrc);
         fileData = await getUint8ArrayFrom(fileSrc, () => null);
     } else {
-        // TODO: support file loading via Open / Drag-n-drop
-        throw new Error("Read from file not yet supported");
+        fileName = fileSrc.name;
+        fileData = new Uint8Array(await fileSrc.arrayBuffer());
     }
 
     return {

--- a/new-log-viewer/src/services/MainWorker.ts
+++ b/new-log-viewer/src/services/MainWorker.ts
@@ -48,10 +48,10 @@ onmessage = async (ev: MessageEvent<MainWorkerReqMessage>) => {
                     args.decoderOptions
                 );
 
-                postResp(
-                    WORKER_RESP_CODE.NUM_EVENTS,
-                    {numEvents: LOG_FILE_MANAGER.numEvents}
-                );
+                postResp(WORKER_RESP_CODE.LOG_FILE_INFO, {
+                    fileName: LOG_FILE_MANAGER.fileName,
+                    numEvents: LOG_FILE_MANAGER.numEvents,
+                });
                 postResp(
                     WORKER_RESP_CODE.PAGE_DATA,
                     LOG_FILE_MANAGER.loadPage(args.cursor)

--- a/new-log-viewer/src/typings/file.ts
+++ b/new-log-viewer/src/typings/file.ts
@@ -1,0 +1,3 @@
+type OnFileOpenCallback = (file: File) => void;
+
+export type {OnFileOpenCallback};

--- a/new-log-viewer/src/typings/worker.ts
+++ b/new-log-viewer/src/typings/worker.ts
@@ -43,9 +43,9 @@ enum WORKER_REQ_CODE {
 }
 
 enum WORKER_RESP_CODE {
+    LOG_FILE_INFO = "fileInfo",
     PAGE_DATA = "pageData",
-    NUM_EVENTS = "numEvents",
-    NOTIFICATION = "notification"
+    NOTIFICATION = "notification",
 }
 
 type WorkerReqMap = {
@@ -62,18 +62,19 @@ type WorkerReqMap = {
 };
 
 type WorkerRespMap = {
+    [WORKER_RESP_CODE.LOG_FILE_INFO]: {
+        fileName: string,
+        numEvents: number,
+    },
     [WORKER_RESP_CODE.PAGE_DATA]: {
         logs: string,
         beginLineNumToLogEventNum: BeginLineNumToLogEventNumMap,
         cursorLineNum: number
-    };
-    [WORKER_RESP_CODE.NUM_EVENTS]: {
-        numEvents: number
-    };
+    },
     [WORKER_RESP_CODE.NOTIFICATION]: {
         logLevel: LOG_LEVEL,
         message: string
-    };
+    },
 };
 
 type WorkerReq<T extends WORKER_REQ_CODE> = T extends keyof WorkerReqMap ?

--- a/new-log-viewer/src/utils/file.ts
+++ b/new-log-viewer/src/utils/file.ts
@@ -1,4 +1,5 @@
-type OnFileOpenCallback = (file: File) => void;
+import type {OnFileOpenCallback} from "../typings/file";
+
 
 /**
  * Open a file and invokes the provided callback on the file.
@@ -22,4 +23,3 @@ const openFile = (onOpen: OnFileOpenCallback) => {
 };
 
 export {openFile};
-export type {OnFileOpenCallback};

--- a/new-log-viewer/src/utils/file.ts
+++ b/new-log-viewer/src/utils/file.ts
@@ -2,7 +2,7 @@ import type {OnFileOpenCallback} from "../typings/file";
 
 
 /**
- * Open a file and invokes the provided callback on the file.
+ * Opens a file and invokes the provided callback on the file.
  *
  * @param onOpen
  */

--- a/new-log-viewer/src/utils/file.ts
+++ b/new-log-viewer/src/utils/file.ts
@@ -13,7 +13,7 @@ const openFile = (onOpen: OnFileOpenCallback) => {
         const target = ev.target as HTMLInputElement;
         const [file] = target.files as FileList;
         if ("undefined" === typeof file) {
-            console.error("No file is selected");
+            console.error("No file selected");
 
             return;
         }

--- a/new-log-viewer/src/utils/file.ts
+++ b/new-log-viewer/src/utils/file.ts
@@ -1,0 +1,25 @@
+type OnFileOpenCallback = (file: File) => void;
+
+/**
+ * Open a file and invokes the provided callback on the file.
+ *
+ * @param onOpen
+ */
+const openFile = (onOpen: OnFileOpenCallback) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.onchange = (ev: Event) => {
+        const target = ev.target as HTMLInputElement;
+        const [file] = target.files as FileList;
+        if ("undefined" === typeof file) {
+            console.error("No file is selected");
+
+            return;
+        }
+        onOpen(file);
+    };
+    input.click();
+};
+
+export {openFile};
+export type {OnFileOpenCallback};


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
new-log-viewer series: #45 #46 #48 #51 #52 #53 #54 #55

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Add local file load support.
2. Display file name in the UI.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Referred to the validation steps in #46 to start the debug server.
3. Clicked button "Open File" and selected `example.jsonl` in the file open dialog.
4. Observed the file getting loaded with logEventNum set to the last event in the log file.
5. Changed value in logEventNum debug input box to `1` and observed the first page got loaded.
