### PR TITLE
new-log-viewer: Add `ClpIrDecoder`.

### DIFF
--- a/new-log-viewer/package-lock.json
+++ b/new-log-viewer/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.7.2",
+        "clp-ffi-js": "^0.1.0",
         "dayjs": "^1.11.11",
         "monaco-editor": "^0.50.0",
         "react": "^18.3.1",
@@ -3995,6 +3996,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/clp-ffi-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clp-ffi-js/-/clp-ffi-js-0.1.0.tgz",
+      "integrity": "sha512-/g1EBxKDd6syknCGj7c/pM4tl1nEhLfRRf8zwaAfDQBxWcO0isXREFya8+TBVm2KTuik9O8hb9HidR17LtI3jg==",
+      "license": "Apache-2.0"
     },
     "node_modules/color-convert": {
       "version": "1.9.3",

--- a/new-log-viewer/package.json
+++ b/new-log-viewer/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/y-scope/yscope-log-viewer#readme",
   "dependencies": {
     "axios": "^1.7.2",
+    "clp-ffi-js": "^0.1.0",
     "dayjs": "^1.11.11",
     "monaco-editor": "^0.50.0",
     "react": "^18.3.1",

--- a/new-log-viewer/src/services/LogFileManager.ts
+++ b/new-log-viewer/src/services/LogFileManager.ts
@@ -1,6 +1,7 @@
 import {
     Decoder,
     DecoderOptionsType,
+    FULL_RANGE_END_IDX,
 } from "../typings/decoders";
 import {MAX_V8_STRING_LENGTH} from "../typings/js";
 import {
@@ -73,7 +74,10 @@ class LogFileManager {
         this.#decoder = decoder;
 
         // Build indices for full range
-        this.#decoder.buildIdx(0, 0);
+        const buildIdxResult = decoder.buildIdx(0, FULL_RANGE_END_IDX);
+        if (null !== buildIdxResult && 0 < buildIdxResult.numInvalidEvents) {
+            console.error("Invalid events found in decoder.buildIdx():", buildIdxResult);
+        }
 
         this.#numEvents = decoder.getEstimatedNumEvents();
         console.log(`Found ${this.#numEvents} log events.`);

--- a/new-log-viewer/src/services/LogFileManager.ts
+++ b/new-log-viewer/src/services/LogFileManager.ts
@@ -1,7 +1,7 @@
 import {
     Decoder,
     DecoderOptionsType,
-    FULL_RANGE_END_IDX,
+    LOG_EVENT_FILE_END_IDX,
 } from "../typings/decoders";
 import {MAX_V8_STRING_LENGTH} from "../typings/js";
 import {
@@ -74,7 +74,7 @@ class LogFileManager {
         this.#decoder = decoder;
 
         // Build index for the entire file
-        const buildIdxResult = decoder.buildIdx(0, FULL_RANGE_END_IDX);
+        const buildIdxResult = decoder.buildIdx(0, LOG_EVENT_FILE_END_IDX);
         if (null !== buildIdxResult && 0 < buildIdxResult.numInvalidEvents) {
             console.error("Invalid events found in decoder.buildIdx():", buildIdxResult);
         }

--- a/new-log-viewer/src/services/LogFileManager.ts
+++ b/new-log-viewer/src/services/LogFileManager.ts
@@ -13,6 +13,7 @@ import {getUint8ArrayFrom} from "../utils/http";
 import {getChunkNum} from "../utils/math";
 import {formatSizeInBytes} from "../utils/units";
 import {getBasenameFromUrlOrDefault} from "../utils/url";
+import ClpIrDecoder from "./decoders/ClpIrDecoder";
 import JsonlDecoder from "./decoders/JsonlDecoder";
 
 
@@ -48,8 +49,6 @@ const loadFile = async (fileSrc: FileSrcType)
 class LogFileManager {
     readonly #pageSize: number;
 
-    readonly #fileData: Uint8Array;
-
     readonly #fileName: string;
 
     #decoder: Decoder;
@@ -60,21 +59,24 @@ class LogFileManager {
      * Private constructor for LogFileManager. This is not intended to be invoked publicly.
      * Instead, use LogFileManager.create() to create a new instance of the class.
      *
+     * @param decoder
      * @param fileName
-     * @param fileData
      * @param pageSize Page size for setting up pagination.
-     * @param decoderOptions Initial decoder options.
      */
     constructor (
+        decoder: Decoder,
         fileName: string,
-        fileData: Uint8Array,
         pageSize: number,
-        decoderOptions: DecoderOptionsType
     ) {
         this.#fileName = fileName;
-        this.#fileData = fileData;
         this.#pageSize = pageSize;
-        this.#decoder = this.#initDecoder(decoderOptions);
+        this.#decoder = decoder;
+
+        // Build indices for full range
+        this.#decoder.buildIdx(0, 0);
+
+        this.#numEvents = decoder.getEstimatedNumEvents();
+        console.log(`Found ${this.#numEvents} log events.`);
     }
 
     get numEvents () {
@@ -96,7 +98,41 @@ class LogFileManager {
         decoderOptions: DecoderOptionsType
     ): Promise<LogFileManager> {
         const {fileName, fileData} = await loadFile(fileSrc);
-        return new LogFileManager(fileName, fileData, pageSize, decoderOptions);
+        const decoder = await LogFileManager.#initDecoder(fileName, fileData, decoderOptions);
+
+        return new LogFileManager(decoder, fileName, pageSize);
+    }
+
+    /**
+     * Constructs a decoder instance based on the file extension.
+     *
+     * @param fileName
+     * @param fileData
+     * @param decoderOptions Initial decoder options.
+     * @return The constructed decoder.
+     * @throws {Error} if a decoder cannot be found.
+     */
+    static async #initDecoder (
+        fileName: string,
+        fileData: Uint8Array,
+        decoderOptions: DecoderOptionsType
+    ): Promise<Decoder> {
+        let decoder: Decoder;
+        if (fileName.endsWith(".jsonl")) {
+            decoder = new JsonlDecoder(fileData, decoderOptions);
+        } else if (fileName.endsWith(".clp.zst")) {
+            decoder = await ClpIrDecoder.create(fileData);
+        } else {
+            throw new Error(`No decoder supports ${fileName}`);
+        }
+
+        if (fileData.length > MAX_V8_STRING_LENGTH) {
+            throw new Error(`Cannot handle files larger than ${
+                formatSizeInBytes(MAX_V8_STRING_LENGTH)
+            } due to a limitation in Chromium-based browsers.`);
+        }
+
+        return decoder;
     }
 
     /**
@@ -153,33 +189,6 @@ class LogFileManager {
             cursorLineNum: 1,
         };
     }
-
-    /**
-     * Constructs a decoder instance based on the file extension.
-     *
-     * @param decoderOptions Initial decoder options.
-     * @return The constructed decoder.
-     * @throws {Error} if a decoder cannot be found.
-     */
-    #initDecoder = (decoderOptions: DecoderOptionsType): Decoder => {
-        let decoder: Decoder;
-        if (this.#fileName.endsWith(".jsonl")) {
-            decoder = new JsonlDecoder(this.#fileData, decoderOptions);
-        } else {
-            throw new Error(`No decoder supports ${this.#fileName}`);
-        }
-
-        if (this.#fileData.length > MAX_V8_STRING_LENGTH) {
-            throw new Error(`Cannot handle files larger than ${
-                formatSizeInBytes(MAX_V8_STRING_LENGTH)
-            } due to a limitation in Chromium-based browsers.`);
-        }
-
-        this.#numEvents = decoder.getEstimatedNumEvents();
-        console.log(`Found ${this.#numEvents} log events.`);
-
-        return decoder;
-    };
 
     /**
      * Gets the range of log event numbers for the page containing the given cursor.

--- a/new-log-viewer/src/services/LogFileManager.ts
+++ b/new-log-viewer/src/services/LogFileManager.ts
@@ -73,7 +73,7 @@ class LogFileManager {
         this.#pageSize = pageSize;
         this.#decoder = decoder;
 
-        // Build indices for full range
+        // Build index for the entire file
         const buildIdxResult = decoder.buildIdx(0, FULL_RANGE_END_IDX);
         if (null !== buildIdxResult && 0 < buildIdxResult.numInvalidEvents) {
             console.error("Invalid events found in decoder.buildIdx():", buildIdxResult);
@@ -114,7 +114,7 @@ class LogFileManager {
      * @param fileData
      * @param decoderOptions Initial decoder options.
      * @return The constructed decoder.
-     * @throws {Error} if a decoder cannot be found.
+     * @throws {Error} if no decoder supports a file with the given extension.
      */
     static async #initDecoder (
         fileName: string,

--- a/new-log-viewer/src/services/decoders/ClpIrDecoder.ts
+++ b/new-log-viewer/src/services/decoders/ClpIrDecoder.ts
@@ -1,4 +1,4 @@
-import clpFfijsModuleInit, {ClpIrStreamReader} from "../../../deps/ClpFfiJs";
+import clpFfijsModuleInit, {ClpIrStreamReader} from "clp-ffi-js";
 import {Nullable} from "../../typings/common";
 import {
     Decoder,

--- a/new-log-viewer/src/services/decoders/ClpIrDecoder.ts
+++ b/new-log-viewer/src/services/decoders/ClpIrDecoder.ts
@@ -1,9 +1,5 @@
-import clpFfijsModuleInit from "../../../deps/ClpFfijs.js";
-import type {
-    ClpIrStreamReader,
-    EmbindModule,
-} from "../../../deps/interface";
-import {Nullable} from "../../typings/common.js";
+import clpFfijsModuleInit, {ClpIrStreamReader} from "../../../deps/ClpFfiJs";
+import {Nullable} from "../../typings/common";
 import {
     Decoder,
     DecodeResultType,
@@ -19,7 +15,7 @@ class ClpIrDecoder implements Decoder {
     }
 
     static async create (dataArray: Uint8Array): Promise<ClpIrDecoder> {
-        const module = await clpFfijsModuleInit() as EmbindModule;
+        const module = await clpFfijsModuleInit();
         const streamReader = new module.ClpIrStreamReader(dataArray);
         return new ClpIrDecoder(streamReader);
     }

--- a/new-log-viewer/src/services/decoders/ClpIrDecoder.ts
+++ b/new-log-viewer/src/services/decoders/ClpIrDecoder.ts
@@ -1,4 +1,8 @@
 import clpFfijsModuleInit from "../../../deps/ClpFfijs.js";
+import type {
+    ClpIrStreamReader,
+    EmbindModule,
+} from "../../../deps/interface";
 import {Nullable} from "../../typings/common.js";
 import {
     Decoder,
@@ -6,17 +10,6 @@ import {
     LogEventCount,
 } from "../../typings/decoders";
 
-
-interface ClpIrStreamReader {
-    getNumEventsBuffered: () => number,
-    deserializeRange: (beginIdx: number, endIdx: number) => number,
-    decodeRange: (beginIdx: number, endIdx: number) => DecodeResultType[],
-}
-
-// FIXME
-interface ClpFfiJsModule {
-    ClpIrStreamReader: ClpIrStreamReader
-}
 
 class ClpIrDecoder implements Decoder {
     #streamReader: ClpIrStreamReader;
@@ -26,8 +19,8 @@ class ClpIrDecoder implements Decoder {
     }
 
     static async create (dataArray: Uint8Array): Promise<ClpIrDecoder> {
-        const module = await clpFfijsModuleInit() as ClpFfiJsModule;
-        const streamReader = new module.ClpIrStreamReader(dataArray) as ClpIrStreamReader;
+        const module = await clpFfijsModuleInit() as EmbindModule;
+        const streamReader = new module.ClpIrStreamReader(dataArray);
         return new ClpIrDecoder(streamReader);
     }
 

--- a/new-log-viewer/src/services/decoders/ClpIrDecoder.ts
+++ b/new-log-viewer/src/services/decoders/ClpIrDecoder.ts
@@ -1,0 +1,56 @@
+import clpFfijsModuleInit from "../../../deps/ClpFfijs.js";
+import {Nullable} from "../../typings/common.js";
+import {
+    Decoder,
+    DecodeResultType,
+    LogEventCount,
+} from "../../typings/decoders";
+
+
+interface ClpIrStreamReader {
+    getNumEventsBuffered: () => number,
+    deserializeRange: (beginIdx: number, endIdx: number) => number,
+    decodeRange: (beginIdx: number, endIdx: number) => DecodeResultType[],
+}
+
+// FIXME
+interface ClpFfiJsModule {
+    ClpIrStreamReader: ClpIrStreamReader
+}
+
+class ClpIrDecoder implements Decoder {
+    #streamReader: ClpIrStreamReader;
+
+    constructor (streamReader: ClpIrStreamReader) {
+        this.#streamReader = streamReader;
+    }
+
+    static async create (dataArray: Uint8Array): Promise<ClpIrDecoder> {
+        const module = await clpFfijsModuleInit() as ClpFfiJsModule;
+        const streamReader = new module.ClpIrStreamReader(dataArray) as ClpIrStreamReader;
+        return new ClpIrDecoder(streamReader);
+    }
+
+    getEstimatedNumEvents (): number {
+        return this.#streamReader.getNumEventsBuffered();
+    }
+
+    buildIdx (beginIdx: number, endIdx: number): Nullable<LogEventCount> {
+        return {
+            numValidEvents: this.#streamReader.deserializeRange(beginIdx, endIdx),
+            numInvalidEvents: 0,
+        };
+    }
+
+    // TODO: add prettify option
+    // eslint-disable-next-line class-methods-use-this
+    setDecoderOptions (): boolean {
+        return true;
+    }
+
+    decode (beginIdx: number, endIdx: number): Nullable<DecodeResultType[]> {
+        return this.#streamReader.decodeRange(beginIdx, endIdx);
+    }
+}
+
+export default ClpIrDecoder;

--- a/new-log-viewer/src/services/decoders/ClpIrDecoder.ts
+++ b/new-log-viewer/src/services/decoders/ClpIrDecoder.ts
@@ -1,4 +1,5 @@
-import clpFfijsModuleInit, {ClpIrStreamReader} from "clp-ffi-js";
+import clpFfiJsModuleInit, {ClpIrStreamReader} from "clp-ffi-js";
+
 import {Nullable} from "../../typings/common";
 import {
     Decoder,
@@ -14,8 +15,14 @@ class ClpIrDecoder implements Decoder {
         this.#streamReader = streamReader;
     }
 
+    /**
+     * Creates a new ClpIrDecoder instance.
+     *
+     * @param dataArray The input data array to be passed to the decoder.
+     * @return The created ClpIrDecoder instance.
+     */
     static async create (dataArray: Uint8Array): Promise<ClpIrDecoder> {
-        const module = await clpFfijsModuleInit();
+        const module = await clpFfiJsModuleInit();
         const streamReader = new module.ClpIrStreamReader(dataArray);
         return new ClpIrDecoder(streamReader);
     }
@@ -26,12 +33,11 @@ class ClpIrDecoder implements Decoder {
 
     buildIdx (beginIdx: number, endIdx: number): Nullable<LogEventCount> {
         return {
-            numValidEvents: this.#streamReader.deserializeRange(beginIdx, endIdx),
             numInvalidEvents: 0,
+            numValidEvents: this.#streamReader.deserializeRange(beginIdx, endIdx),
         };
     }
 
-    // TODO: add prettify option
     // eslint-disable-next-line class-methods-use-this
     setDecoderOptions (): boolean {
         return true;

--- a/new-log-viewer/src/typings/decoders.ts
+++ b/new-log-viewer/src/typings/decoders.ts
@@ -71,7 +71,12 @@ interface Decoder {
     decode(beginIdx: number, endIdx: number): Nullable<DecodeResultType[]>;
 }
 
+/**
+ * The end index for specifying full range when the exact number of log events is unknown.
+ */
+const FULL_RANGE_END_IDX: number = 0;
 
+export {FULL_RANGE_END_IDX};
 export type {
     Decoder,
     DecodeResultType,

--- a/new-log-viewer/src/typings/decoders.ts
+++ b/new-log-viewer/src/typings/decoders.ts
@@ -75,9 +75,9 @@ interface Decoder {
  * Index for specifying the end of the file when the exact number of log events it contains is
  *  unknown.
  */
-const FULL_RANGE_END_IDX: number = 0;
+const LOG_EVENT_FILE_END_IDX: number = 0;
 
-export {FULL_RANGE_END_IDX};
+export {LOG_EVENT_FILE_END_IDX};
 export type {
     Decoder,
     DecodeResultType,

--- a/new-log-viewer/src/typings/decoders.ts
+++ b/new-log-viewer/src/typings/decoders.ts
@@ -72,7 +72,8 @@ interface Decoder {
 }
 
 /**
- * The end index for specifying full range when the exact number of log events is unknown.
+ * Index for specifying the end of the file when the exact number of log events it contains is
+ *  unknown.
  */
 const FULL_RANGE_END_IDX: number = 0;
 

--- a/new-log-viewer/src/typings/decoders.ts
+++ b/new-log-viewer/src/typings/decoders.ts
@@ -45,7 +45,7 @@ interface Decoder {
      * When applicable, deserializes log events in the range `[beginIdx, endIdx)`.
      *
      * @param beginIdx
-     * @param endIdx
+     * @param endIdx End index. To deserialize to the end of the file, use `LOG_EVENT_FILE_END_IDX`.
      * @return Count of the successfully deserialized ("valid") log events and count of any
      * un-deserializable ("invalid") log events within the range; or null if any log event in the
      * range doesn't exist (e.g., the range exceeds the number of log events in the file).


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
new-log-viewer series: #45 #46 #48 #51 #52 #53 #54 #55 #56 #59 #60 #61

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Integrate `clp-ffi-js` as a dependency.
2. Add `ClpIrDecoder`.
3. Since now decoder creations could be asynchronous, move decoder initialization out from LogFileManager's constructor into its factory function.
4. Call `buildIdx()` in LogFileManager's constructor to deserialize the whole input file.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Referred to #46 , started dev server at default address http://localhost:3010/ .
2. Loaded example CLP Stream ("IRv1") file: http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst
3. Validated below functions and observed behaviour matched expectaions:
    1. When loaded without specifying the logEventNum in the app URL, the last page was loaded with the cursor set to the last event.
    2. When loaded with logEventNum in the URL, the first page is shown with the cursor set to the first event.
    3. Within the Monaco editor, tested prevPage, nextPage, firstPage, nextPage with shortcuts, and all worked as expected. (One issue was found when the page switching happens too frequently: it was observed that if nextPage is requested too frequently at a time, we could be seeing pages being loaded in order N (currentPageNum) -> N+1 -> N+2 -> N+1; initial analysis believe this was due to multiple requests getting sent to the service worker on page N which caused concurrency issues. It should be addressed in another PR where posting messages are disabled for certain requests that a response from the server and its corresponding handling completion in the render is expected before another new request can be sent.)
    4. Set page size to 1. Reloaded the app without logEventNum and observed the last page containing only the last event was loaded.
    5. Setting invalid (spaces; i.e., `" "`) JSONL decoder options does not affect the correct behaviours of the CLP Stream decoder.