### PR TITLE
new-log-viewer: Upgrade to TypeScript 5.6.2; Update module resolution to "Bundler" in tsconfig.json to support new TypeScript.

### DIFF
--- a/new-log-viewer/package-lock.json
+++ b/new-log-viewer/package-lock.json
@@ -35,7 +35,7 @@
         "monaco-editor-webpack-plugin": "^7.1.0",
         "react-refresh": "^0.14.2",
         "style-loader": "^4.0.0",
-        "typescript": "^5.4.5",
+        "typescript": "^5.6.2",
         "webpack": "^5.92.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4",
@@ -10072,9 +10072,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/new-log-viewer/package.json
+++ b/new-log-viewer/package.json
@@ -48,7 +48,7 @@
     "monaco-editor-webpack-plugin": "^7.1.0",
     "react-refresh": "^0.14.2",
     "style-loader": "^4.0.0",
-    "typescript": "^5.4.5",
+    "typescript": "^5.6.2",
     "webpack": "^5.92.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4",

--- a/new-log-viewer/tsconfig.json
+++ b/new-log-viewer/tsconfig.json
@@ -42,7 +42,7 @@
     "module": "ESNext",
     /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "Bundler",
     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",
     /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
new-log-viewer series: #45 #46 #48 #51 #52 #53 #54 #55 #56 #59 #60 #61 #62 #63 #66

It was found that after removing `package-lock.json` and re-running `npm i`, now npm resolves TypeScript's version to a newer one which has a different module resolution behaviour with `"moduleResolution": "NodeNext"` in `tsconfig.json`.

Imports from sources without file extensions no longer work. e.g.,
```
TS2835: Relative import paths need explicit file extensions in ECMAScript imports when --moduleResolution is node16 or nodenext. Did you mean ./ decoders. js?
```
Release 5.6 Changelog:
https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#respecting-file-extensions-and-package.json-from-within-node_modules14

Docs:
https://www.typescriptlang.org/tsconfig/#moduleResolution

Discussions:
https://github.com/microsoft/TypeScript/issues/51714

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Upgrade TypeScript version to 5.6.2 explicitly in `package.json`.
2. Update module resolution to "Bundler" in `tsconfig.json`.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. No longer observed the TS2835 issues.