### PR TITLE
new-log-viewer: Add custom Monaco editor themes and a Monaco language for logs.

### DIFF
--- a/new-log-viewer/src/components/Editor/MonacoInstance/index.tsx
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/index.tsx
@@ -102,7 +102,7 @@ const MonacoInstance = ({
         onMount,
     ]);
 
-    // On `themeName` update, set theme in the editor.
+    // On `themeName` update, set the theme in the editor.
     useEffect(() => {
         monaco.editor.setTheme(themeName);
     }, [themeName]);

--- a/new-log-viewer/src/components/Editor/MonacoInstance/index.tsx
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/index.tsx
@@ -26,7 +26,7 @@ interface MonacoEditorProps {
     actions: ActionType[],
     lineNum: number,
     text: string,
-    themeName: string,
+    themeName: "dark" | "light",
 
     beforeMount?: BeforeMountCallback,
     beforeTextUpdate?: BeforeTextUpdateCallback,

--- a/new-log-viewer/src/components/Editor/MonacoInstance/index.tsx
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/index.tsx
@@ -23,9 +23,11 @@ import "./index.css";
 
 
 interface MonacoEditorProps {
+    actions: ActionType[],
     lineNum: number,
     text: string,
-    actions: ActionType[],
+    themeName: string,
+
     beforeMount?: BeforeMountCallback,
     beforeTextUpdate?: BeforeTextUpdateCallback,
     onCursorExplicitPosChange: CursorExplicitPosChangeCallback,
@@ -40,9 +42,10 @@ interface MonacoEditorProps {
  * the editor.
  *
  * @param props
+ * @param props.actions
  * @param props.lineNum
  * @param props.text
- * @param props.actions
+ * @param props.themeName
  * @param props.beforeMount
  * @param props.beforeTextUpdate
  * @param props.onCursorExplicitPosChange
@@ -52,9 +55,10 @@ interface MonacoEditorProps {
  * @return
  */
 const MonacoInstance = ({
+    actions,
     lineNum,
     text,
-    actions,
+    themeName,
     beforeMount,
     beforeTextUpdate,
     onMount,
@@ -97,6 +101,11 @@ const MonacoInstance = ({
         onCustomAction,
         onMount,
     ]);
+
+    // On `themeName` update, set theme in the editor.
+    useEffect(() => {
+        monaco.editor.setTheme(themeName);
+    }, [themeName]);
 
     // On `text` update, set the text and position cursor in the editor.
     useEffect(() => {

--- a/new-log-viewer/src/components/Editor/MonacoInstance/language.ts
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/language.ts
@@ -1,6 +1,6 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 
-import {TOKEN_NAMES} from "./typings";
+import {TOKEN_NAME} from "./typings";
 
 
 const LOG_LANGUAGE_NAME = "logLanguage";
@@ -17,13 +17,13 @@ const setupCustomLogLanguage = () => {
         tokenizer: {
             root: [
                 /* eslint-disable @stylistic/js/array-element-newline */
-                ["INFO", TOKEN_NAMES.CUSTOM_INFO],
-                ["WARN", TOKEN_NAMES.CUSTOM_WARN],
-                ["ERROR", TOKEN_NAMES.CUSTOM_ERROR],
-                ["FATAL", TOKEN_NAMES.CUSTOM_FATAL],
-                [/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})Z/, TOKEN_NAMES.CUSTOM_DATE],
-                [/^[\t ]*at.*$/, TOKEN_NAMES.CUSTOM_EXCEPTION],
-                [/(\d+(?:\.\d+)?([eE])([+-])[0-9](\.[0-9])?|\d+(?:\.\d+)?)/, TOKEN_NAMES.CUSTOM_NUMBER],
+                ["INFO", TOKEN_NAME.CUSTOM_INFO],
+                ["WARN", TOKEN_NAME.CUSTOM_WARN],
+                ["ERROR", TOKEN_NAME.CUSTOM_ERROR],
+                ["FATAL", TOKEN_NAME.CUSTOM_FATAL],
+                [/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})Z/, TOKEN_NAME.CUSTOM_DATE],
+                [/^[\t ]*at.*$/, TOKEN_NAME.CUSTOM_EXCEPTION],
+                [/(\d+(?:\.\d+)?([eE])([+-])[0-9](\.[0-9])?|\d+(?:\.\d+)?)/, TOKEN_NAME.CUSTOM_NUMBER],
                 /* eslint-enable @stylistic/js/array-element-newline */
             ],
         },

--- a/new-log-viewer/src/components/Editor/MonacoInstance/language.ts
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/language.ts
@@ -16,15 +16,34 @@ const setupCustomLogLanguage = () => {
     monaco.languages.setMonarchTokensProvider(LOG_LANGUAGE_NAME, {
         tokenizer: {
             root: [
-                /* eslint-disable @stylistic/js/array-element-newline */
-                ["INFO", TOKEN_NAME.CUSTOM_INFO],
-                ["WARN", TOKEN_NAME.CUSTOM_WARN],
-                ["ERROR", TOKEN_NAME.CUSTOM_ERROR],
-                ["FATAL", TOKEN_NAME.CUSTOM_FATAL],
-                [/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})Z/, TOKEN_NAME.CUSTOM_DATE],
-                [/^[\t ]*at.*$/, TOKEN_NAME.CUSTOM_EXCEPTION],
-                [/(\d+(?:\.\d+)?([eE])([+-])[0-9](\.[0-9])?|\d+(?:\.\d+)?)/, TOKEN_NAME.CUSTOM_NUMBER],
-                /* eslint-enable @stylistic/js/array-element-newline */
+                [
+                    "INFO",
+                    TOKEN_NAME.CUSTOM_INFO,
+                ],
+                [
+                    "WARN",
+                    TOKEN_NAME.CUSTOM_WARN,
+                ],
+                [
+                    "ERROR",
+                    TOKEN_NAME.CUSTOM_ERROR,
+                ],
+                [
+                    "FATAL",
+                    TOKEN_NAME.CUSTOM_FATAL,
+                ],
+                [
+                    /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})Z/,
+                    TOKEN_NAME.CUSTOM_DATE,
+                ],
+                [
+                    /^[\t ]*at.*$/,
+                    TOKEN_NAME.CUSTOM_EXCEPTION,
+                ],
+                [
+                    /(\d+(?:\.\d+)?([eE])([+-])[0-9](\.[0-9])?|\d+(?:\.\d+)?)/,
+                    TOKEN_NAME.CUSTOM_NUMBER,
+                ],
             ],
         },
     });

--- a/new-log-viewer/src/components/Editor/MonacoInstance/language.ts
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/language.ts
@@ -1,0 +1,36 @@
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
+
+import {TOKEN_NAMES} from "./typings";
+
+
+const LOG_LANGUAGE_NAME = "logLanguage";
+
+
+/**
+ * Registers a custom log language in the Monaco editor.
+ */
+const setupCustomLogLanguage = () => {
+    monaco.languages.register({
+        id: LOG_LANGUAGE_NAME,
+    });
+    monaco.languages.setMonarchTokensProvider(LOG_LANGUAGE_NAME, {
+        tokenizer: {
+            root: [
+                /* eslint-disable @stylistic/js/array-element-newline */
+                ["INFO", TOKEN_NAMES.CUSTOM_INFO],
+                ["WARN", TOKEN_NAMES.CUSTOM_WARN],
+                ["ERROR", TOKEN_NAMES.CUSTOM_ERROR],
+                ["FATAL", TOKEN_NAMES.CUSTOM_FATAL],
+                [/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})Z/, TOKEN_NAMES.CUSTOM_DATE],
+                [/^[\t ]*at.*$/, TOKEN_NAMES.CUSTOM_EXCEPTION],
+                [/(\d+(?:\.\d+)?([eE])([+-])[0-9](\.[0-9])?|\d+(?:\.\d+)?)/, TOKEN_NAMES.CUSTOM_NUMBER],
+                /* eslint-enable @stylistic/js/array-element-newline */
+            ],
+        },
+    });
+};
+
+export {
+    LOG_LANGUAGE_NAME,
+    setupCustomLogLanguage,
+};

--- a/new-log-viewer/src/components/Editor/MonacoInstance/theme.ts
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/theme.ts
@@ -1,7 +1,7 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 
 import {THEME_NAME} from "../../../typings/config";
-import {TOKEN_NAMES} from "./typings";
+import {TOKEN_NAME} from "./typings";
 
 
 /**
@@ -12,14 +12,14 @@ const setupThemes = () => {
         base: "vs-dark",
         inherit: true,
         rules: [
-            {token: TOKEN_NAMES.CUSTOM_INFO, foreground: "#098658"},
-            {token: TOKEN_NAMES.CUSTOM_WARN, foreground: "#ce9178"},
-            {token: TOKEN_NAMES.CUSTOM_ERROR, foreground: "#ce9178", fontStyle: "bold"},
-            {token: TOKEN_NAMES.CUSTOM_FATAL, foreground: "#ce9178", fontStyle: "bold"},
-            {token: TOKEN_NAMES.CUSTOM_DATE, foreground: "#529955"},
-            {token: TOKEN_NAMES.CUSTOM_EXCEPTION, foreground: "#ce723b", fontStyle: "italic"},
-            {token: TOKEN_NAMES.CUSTOM_NUMBER, foreground: "#3f9ccb"},
-            {token: TOKEN_NAMES.COMMENT, foreground: "#008000"},
+            {token: TOKEN_NAME.CUSTOM_INFO, foreground: "#098658"},
+            {token: TOKEN_NAME.CUSTOM_WARN, foreground: "#ce9178"},
+            {token: TOKEN_NAME.CUSTOM_ERROR, foreground: "#ce9178", fontStyle: "bold"},
+            {token: TOKEN_NAME.CUSTOM_FATAL, foreground: "#ce9178", fontStyle: "bold"},
+            {token: TOKEN_NAME.CUSTOM_DATE, foreground: "#529955"},
+            {token: TOKEN_NAME.CUSTOM_EXCEPTION, foreground: "#ce723b", fontStyle: "italic"},
+            {token: TOKEN_NAME.CUSTOM_NUMBER, foreground: "#3f9ccb"},
+            {token: TOKEN_NAME.COMMENT, foreground: "#008000"},
         ],
         colors: {
             "editor.lineHighlightBackground": "#3c3c3c",
@@ -29,13 +29,13 @@ const setupThemes = () => {
         base: "vs",
         inherit: true,
         rules: [
-            {token: TOKEN_NAMES.CUSTOM_INFO, foreground: "#098658"},
-            {token: TOKEN_NAMES.CUSTOM_WARN, foreground: "#b81560"},
-            {token: TOKEN_NAMES.CUSTOM_ERROR, foreground: "#ac1515", fontStyle: "bold"},
-            {token: TOKEN_NAMES.CUSTOM_FATAL, foreground: "#ac1515", fontStyle: "bold"},
-            {token: TOKEN_NAMES.CUSTOM_DATE, foreground: "#008000"},
-            {token: TOKEN_NAMES.CUSTOM_EXCEPTION, foreground: "#ce723b", fontStyle: "italic"},
-            {token: TOKEN_NAMES.CUSTOM_NUMBER, foreground: "#3f9ccb"},
+            {token: TOKEN_NAME.CUSTOM_INFO, foreground: "#098658"},
+            {token: TOKEN_NAME.CUSTOM_WARN, foreground: "#b81560"},
+            {token: TOKEN_NAME.CUSTOM_ERROR, foreground: "#ac1515", fontStyle: "bold"},
+            {token: TOKEN_NAME.CUSTOM_FATAL, foreground: "#ac1515", fontStyle: "bold"},
+            {token: TOKEN_NAME.CUSTOM_DATE, foreground: "#008000"},
+            {token: TOKEN_NAME.CUSTOM_EXCEPTION, foreground: "#ce723b", fontStyle: "italic"},
+            {token: TOKEN_NAME.CUSTOM_NUMBER, foreground: "#3f9ccb"},
         ],
         colors: {},
     });

--- a/new-log-viewer/src/components/Editor/MonacoInstance/theme.ts
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/theme.ts
@@ -1,0 +1,45 @@
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
+
+import {THEME_NAME} from "../../../typings/config";
+import {TOKEN_NAMES} from "./typings";
+
+
+/**
+ * Sets up custom themes for the Monaco editor.
+ */
+const setupThemes = () => {
+    monaco.editor.defineTheme(THEME_NAME.DARK, {
+        base: "vs-dark",
+        inherit: true,
+        rules: [
+            {token: TOKEN_NAMES.CUSTOM_INFO, foreground: "#098658"},
+            {token: TOKEN_NAMES.CUSTOM_WARN, foreground: "#ce9178"},
+            {token: TOKEN_NAMES.CUSTOM_ERROR, foreground: "#ce9178", fontStyle: "bold"},
+            {token: TOKEN_NAMES.CUSTOM_FATAL, foreground: "#ce9178", fontStyle: "bold"},
+            {token: TOKEN_NAMES.CUSTOM_DATE, foreground: "#529955"},
+            {token: TOKEN_NAMES.CUSTOM_EXCEPTION, foreground: "#ce723b", fontStyle: "italic"},
+            {token: TOKEN_NAMES.CUSTOM_NUMBER, foreground: "#3f9ccb"},
+            {token: TOKEN_NAMES.COMMENT, foreground: "#008000"},
+        ],
+        colors: {
+            "editor.lineHighlightBackground": "#3c3c3c",
+        },
+    });
+    monaco.editor.defineTheme(THEME_NAME.LIGHT, {
+        base: "vs",
+        inherit: true,
+        rules: [
+            {token: TOKEN_NAMES.CUSTOM_INFO, foreground: "#098658"},
+            {token: TOKEN_NAMES.CUSTOM_WARN, foreground: "#b81560"},
+            {token: TOKEN_NAMES.CUSTOM_ERROR, foreground: "#ac1515", fontStyle: "bold"},
+            {token: TOKEN_NAMES.CUSTOM_FATAL, foreground: "#ac1515", fontStyle: "bold"},
+            {token: TOKEN_NAMES.CUSTOM_DATE, foreground: "#008000"},
+            {token: TOKEN_NAMES.CUSTOM_EXCEPTION, foreground: "#ce723b", fontStyle: "italic"},
+            {token: TOKEN_NAMES.CUSTOM_NUMBER, foreground: "#3f9ccb"},
+        ],
+        colors: {},
+    });
+};
+
+
+export {setupThemes};

--- a/new-log-viewer/src/components/Editor/MonacoInstance/typings.ts
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/typings.ts
@@ -7,7 +7,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 import {ACTION_NAME} from "../../../utils/actions";
 
 
-enum TOKEN_NAMES {
+enum TOKEN_NAME {
     CUSTOM_INFO = "customInfo",
     CUSTOM_WARN = "customWarn",
     CUSTOM_ERROR = "customError",
@@ -66,7 +66,7 @@ interface CustomMonacoEditorHandlers {
     onCustomAction?: CustomActionCallback,
 }
 
-export {TOKEN_NAMES};
+export {TOKEN_NAME};
 export type {
     BeforeMountCallback,
     BeforeTextUpdateCallback,

--- a/new-log-viewer/src/components/Editor/MonacoInstance/typings.ts
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/typings.ts
@@ -7,6 +7,17 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 import {ACTION_NAME} from "../../../utils/actions";
 
 
+enum TOKEN_NAMES {
+    CUSTOM_INFO = "customInfo",
+    CUSTOM_WARN = "customEarn",
+    CUSTOM_ERROR = "customError",
+    CUSTOM_FATAL = "customFatal",
+    CUSTOM_DATE = "customDate",
+    CUSTOM_EXCEPTION = "customException",
+    CUSTOM_NUMBER = "customNumber",
+    COMMENT = "comment",
+}
+
 /**
  * Gets called when the cursor position is explicitly changed in the editor.
  *
@@ -55,6 +66,7 @@ interface CustomMonacoEditorHandlers {
     onCustomAction?: CustomActionCallback,
 }
 
+export {TOKEN_NAMES};
 export type {
     BeforeMountCallback,
     BeforeTextUpdateCallback,

--- a/new-log-viewer/src/components/Editor/MonacoInstance/typings.ts
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/typings.ts
@@ -9,7 +9,7 @@ import {ACTION_NAME} from "../../../utils/actions";
 
 enum TOKEN_NAMES {
     CUSTOM_INFO = "customInfo",
-    CUSTOM_WARN = "customEarn",
+    CUSTOM_WARN = "customWarn",
     CUSTOM_ERROR = "customError",
     CUSTOM_FATAL = "customFatal",
     CUSTOM_DATE = "customDate",

--- a/new-log-viewer/src/components/Editor/MonacoInstance/utils.ts
+++ b/new-log-viewer/src/components/Editor/MonacoInstance/utils.ts
@@ -7,6 +7,11 @@ import {
     setupFocusOnBacktickDown,
     setupMobileZoom,
 } from "./actions";
+import {
+    LOG_LANGUAGE_NAME,
+    setupCustomLogLanguage,
+} from "./language";
+import {setupThemes} from "./theme";
 import {CustomMonacoEditorHandlers} from "./typings";
 
 
@@ -38,12 +43,16 @@ const createMonacoEditor = (
     actions: ActionType[],
     handlers: CustomMonacoEditorHandlers
 ): monaco.editor.IStandaloneCodeEditor => {
+    setupCustomLogLanguage();
+    setupThemes();
+
     const editor = monaco.editor.create(
         editorContainer,
         {
             // eslint-disable-next-line no-warning-comments
             // TODO: Add custom observer to debounce automatic layout
             automaticLayout: true,
+            language: LOG_LANGUAGE_NAME,
             maxTokenizationLineLength: 30_000,
             mouseWheelZoom: true,
             readOnly: true,

--- a/new-log-viewer/src/components/Editor/index.tsx
+++ b/new-log-viewer/src/components/Editor/index.tsx
@@ -8,6 +8,8 @@ import {
 
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 
+import {useColorScheme} from "@mui/joy";
+
 import {StateContext} from "../../contexts/StateContextProvider";
 import {
     updateWindowUrlHashParams,
@@ -42,6 +44,8 @@ import "./index.css";
  * @return
  */
 const Editor = () => {
+    const {mode, systemMode} = useColorScheme();
+
     const {beginLineNumToLogEventNum, logData, numEvents} = useContext(StateContext);
     const {logEventNum} = useContext(UrlContext);
 
@@ -185,6 +189,10 @@ const Editor = () => {
         beginLineNumToLogEventNum,
     ]);
 
+    const themeName = (("system" === mode) ?
+        systemMode :
+        mode) ?? "dark";
+
     return (
         <div className={"editor"}>
             <MonacoInstance
@@ -192,6 +200,7 @@ const Editor = () => {
                 beforeTextUpdate={resetCachedPageSize}
                 lineNum={lineNum}
                 text={logData}
+                themeName={themeName}
                 onCursorExplicitPosChange={handleCursorExplicitPosChange}
                 onCustomAction={handleEditorCustomAction}
                 onMount={handleMount}

--- a/new-log-viewer/src/components/Editor/index.tsx
+++ b/new-log-viewer/src/components/Editor/index.tsx
@@ -16,7 +16,10 @@ import {
     UrlContext,
 } from "../../contexts/UrlContextProvider";
 import {Nullable} from "../../typings/common";
-import {CONFIG_KEY} from "../../typings/config";
+import {
+    CONFIG_KEY,
+    THEME_NAME,
+} from "../../typings/config";
 import {BeginLineNumToLogEventNumMap} from "../../typings/worker";
 import {
     ACTION_NAME,
@@ -191,7 +194,7 @@ const Editor = () => {
 
     const themeName = (("system" === mode) ?
         systemMode :
-        mode) ?? "dark";
+        mode) ?? THEME_NAME.DARK;
 
     return (
         <div className={"editor"}>

--- a/new-log-viewer/src/components/Editor/index.tsx
+++ b/new-log-viewer/src/components/Editor/index.tsx
@@ -42,6 +42,20 @@ import "./index.css";
 
 
 /**
+ * Resets the cached page size in case it causes a client OOM. If it doesn't, the saved value
+ * will be restored when {@link restoreCachedPageSize} is called.
+ */
+const resetCachedPageSize = () => {
+    const error = setConfig(
+        {key: CONFIG_KEY.PAGE_SIZE, value: CONFIG_DEFAULT[CONFIG_KEY.PAGE_SIZE]}
+    );
+
+    if (null !== error) {
+        console.error(`Unexpected error returned by setConfig(): ${error}`);
+    }
+};
+
+/**
  * Renders a read-only editor for viewing logs.
  *
  * @return
@@ -105,20 +119,6 @@ const Editor = () => {
         editor.onMouseUp(() => {
             isMouseDownRef.current = false;
         });
-    }, []);
-
-    /**
-     * Resets the cached page size in case it causes a client OOM. If it doesn't, the saved value
-     * will be restored when {@link restoreCachedPageSize} is called.
-     */
-    const resetCachedPageSize = useCallback(() => {
-        const error = setConfig(
-            {key: CONFIG_KEY.PAGE_SIZE, value: CONFIG_DEFAULT[CONFIG_KEY.PAGE_SIZE]}
-        );
-
-        if (null !== error) {
-            console.error(`Unexpected error returned by setConfig(): ${error}`);
-        }
     }, []);
 
     /**
@@ -192,10 +192,6 @@ const Editor = () => {
         beginLineNumToLogEventNum,
     ]);
 
-    const themeName = (("system" === mode) ?
-        systemMode :
-        mode) ?? THEME_NAME.DARK;
-
     return (
         <div className={"editor"}>
             <MonacoInstance
@@ -203,7 +199,9 @@ const Editor = () => {
                 beforeTextUpdate={resetCachedPageSize}
                 lineNum={lineNum}
                 text={logData}
-                themeName={themeName}
+                themeName={(("system" === mode) ?
+                    systemMode :
+                    mode) ?? THEME_NAME.DARK}
                 onCursorExplicitPosChange={handleCursorExplicitPosChange}
                 onCustomAction={handleEditorCustomAction}
                 onMount={handleMount}


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
new-log-viewer series: #45 #46 #48 #51 #52 #53 #54 #55 #56 #59 #60 #61 #62 #63 #66 #67 #68
#59 added theming support via JoyUI.
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Add custom log language to Monaco editor.
2. Add custom themes to Monaco editor which specifies colors on the language tokens.
3. Synchronize the Monaco editor's theme with JoyUI's "mode".

# Validation performed
<!-- What tests and validation you performed on the change -->
1. On Windows, set system color mode to "light" in the settings app; cleared browser caches.
2. Referred to #46, started dev server and loaded example file https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst .
3. Observed the app (menu bar, editor, and status bar) loaded in "light" theme, and the dates, log levels and numbers are correctly highlighted with a light editor background.
4. Opened the settings modal, observed the color mode was "system".
5. Changed the color mode to "dark" and observed the app loaded in "dark" theme, and the dates, log levels and numbers are correctly highlighted with a dark editor background.
6. Changed the color mode to "light" and observed the app loaded in "light" theme, and the dates, log levels and numbers are correctly highlighted with a light editor background.
