### PR TITLE
new-log-viewer: Treat ESLint warnings as errors; Remove `ataylorme/eslint-annotate-action` and instead rely on `setup-node`'s problem matcher to annotate ESLint errors in PRs.

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,11 +21,6 @@ concurrency:
 jobs:
   lint-check:
     runs-on: "ubuntu-latest"
-    permissions:
-      # So `eslint-annotate-action` can create / update status checks
-      checks: "write"
-      # So `eslint-annotate-action` can get pull request files
-      contents: "read"
     steps:
       - uses: "actions/checkout@v4"
         with:
@@ -35,10 +30,3 @@ jobs:
           node-version: 22
       - run: "npm --prefix new-log-viewer/ clean-install"
       - run: "npm --prefix new-log-viewer/ run lint:ci"
-        continue-on-error: true
-      - uses: "ataylorme/eslint-annotate-action@v3"
-        with:
-          fail-on-error: true
-          fail-on-warning: true
-          only-pr-files: true
-          report-json: "./new-log-viewer/eslint-report.json"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,4 +29,4 @@ jobs:
         with:
           node-version: 22
       - run: "npm --prefix new-log-viewer/ clean-install"
-      - run: "npm --prefix new-log-viewer/ run lint:ci"
+      - run: "npm --prefix new-log-viewer/ run lint:check"

--- a/new-log-viewer/package.json
+++ b/new-log-viewer/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "build": "webpack --config webpack.prod.js",
     "lint": "npm run lint:check",
-    "lint:ci": "npm run lint:check -- --max-warnings 0",
-    "lint:check": "eslint src webpack.*.js",
+    "lint:check": "eslint src webpack.*.js --max-warnings 0",
     "lint:fix": "npm run lint:check -- --fix",
     "start": "webpack serve --open --config webpack.dev.js"
   },

--- a/new-log-viewer/package.json
+++ b/new-log-viewer/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack --config webpack.prod.js",
     "lint": "npm run lint:check",
-    "lint:ci": "npm run lint:check -- --output-file eslint-report.json --format json",
+    "lint:ci": "npm run lint:check -- --max-warnings 0",
     "lint:check": "eslint src webpack.*.js",
     "lint:fix": "npm run lint:check -- --fix",
     "start": "webpack serve --open --config webpack.dev.js"


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
new-log-viewer series: #45 #46 #48 #51 #52 #53 #54 #55 #56 #59 #60 #61 #62 #63 #66 #67 #68

#61 added lint workflow for the new-log-viewer; #68 updates the lint workflow trigger condition to include PR "synchronize" - pushes to the PR source branch.

After the lint workflow was added, it was found that the ESLint analysis action "ataylorme/eslint-annotate-action@v3" uses permissions including but not limited to "checks: write" [1][2], which is beyond the maximum access for pull requests from public forked repositories (all "read" only)[3], and lint errors are not getting reported directly in PR changed files, causing confusions and void the efforts for lint check automations.

One viable solution is to create a Personal Access Token (PAT), store it as a repository secret and use it instead of `secrets.GITHUB_TOKEN` in the workflow. At the moment, there are two types of PAT that GitHub offers: "classic" and "fine-grained" with the later still in "beta" phase. The "classic" type does not offer options to configure in which repository the accesses can be granted; while the "fine-grained" type does not seem to offer "checks" permission grants. As a result, there is no clean way to obtain a token dedicated for linting in this specific repo.

On the other hand, we can fallback to having the lint results output to the console and rely on "problem matchers" to annotate any potential issues. In fact, the `actions/setup-node@v4` action used in the workflow provides an ESLint problem matcher already.

[1] https://github.com/ataylorme/eslint-annotate-action/issues/42
[2] https://github.com/ataylorme/eslint-annotate-action/blob/3470c7a7e9a4e5ae2d7276a547691f31015ed721/src/createStatusCheck.ts
[3] https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#:~:text=Maximum%20access%20for%0Apull%20requests%20from%0Apublic%20forked%20repositories
[4] https://github.com/actions/setup-node/blob/main/.github/eslint-stylish.json
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Replace custom action with problem matcher for ESLint issue display in new-log-viewer lint workflow.
2. Change `lint:ci` npm script to now output to console directly and exit with non-zero code on warnings.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. With another GitHub account, created a fork from `junhaoliao/yscope-log-viewer`.
2. Made lint violations including errors and warnings on the forked repo's branch.
3. Created a PR from the forked repo to `junhaoliao/yscope-log-viewer`.
4. (Junhao approved the PR workflow run since the new account is a first-time contributor to the repo.) The workflow ran and the lint warnings and errors got marked in the PR's "Files changed" tab.

PR Link: https://github.com/junhaoliao/yscope-log-viewer/pull/10/files