### PR TITLE
new-log-viewer: Replace fallback font with `Inter`.

### DIFF
--- a/new-log-viewer/public/index.html
+++ b/new-log-viewer/public/index.html
@@ -10,6 +10,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" crossorigin href="https://fonts.gstatic.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
+    <link rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+    />
 </head>
 <body>
 <div id="root"></div>

--- a/new-log-viewer/public/index.html
+++ b/new-log-viewer/public/index.html
@@ -9,10 +9,8 @@
     <meta name="viewport" content="initial-scale=1, maximum-scale=1">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" crossorigin href="https://fonts.gstatic.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
     <link rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
-    />
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" />
 </head>
 <body>
 <div id="root"></div>

--- a/new-log-viewer/public/index.html
+++ b/new-log-viewer/public/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" crossorigin href="https://fonts.gstatic.com">
     <link rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap">
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300...700&display=swap">
 </head>
 <body>
 <div id="root"></div>

--- a/new-log-viewer/public/index.html
+++ b/new-log-viewer/public/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" crossorigin href="https://fonts.gstatic.com">
     <link rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@300...700&display=swap">
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap">
 </head>
 <body>
 <div id="root"></div>

--- a/new-log-viewer/public/index.html
+++ b/new-log-viewer/public/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" crossorigin href="https://fonts.gstatic.com">
     <link rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" />
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap">
 </head>
 <body>
 <div id="root"></div>

--- a/new-log-viewer/src/index.css
+++ b/new-log-viewer/src/index.css
@@ -13,7 +13,7 @@ html {
 :root {
     /* font-family globals */
     --ylv-ui-font-family: -apple-system, "BlinkMacSystemFont", system-ui, "Ubuntu", "Droid Sans",
-        "Roboto";
+        "Inter";
 
     /* size globals */
     --ylv-status-bar-height: 32px;


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
new-log-viewer series: #45 #46 #48 #51 #52 #53 #54 #55 #56 #59 #60 #61 #62 #63 #66 #67 #68 #69 #70 #71 #72 #73 #74 #76

Joy UI Installation: [Inter font](https://mui.com/joy-ui/getting-started/installation/#inter-font): [Google Web Fonts](https://mui.com/joy-ui/getting-started/installation/#google-web-fonts)
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Add Inter font for improved typography with Joy UI.
2. Replace fallback font "Roboto" from `--ylv-ui-font-family` with `Inter` and remove imports for "Roboto".

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Referred to #46 , launched debug server and loaded the log-viewer in a Chromium-based (e.g. Microsoft Edge) browser window.
3. Opened the browser's debugger and selected tab "Elements". Inspected the `<head/>` tag and confirmed the `<link/>` element for Inter font has been added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for the "Inter" font family in the application, enhancing typography options.

- **Style**
	- Updated the global font-family to "Inter" for improved text appearance across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->