### PR TITLE
new-log-viewer: Add bounds checking and search methods to support log filtering around a specific log event.

### DIFF
--- a/new-log-viewer/src/utils/data.ts
+++ b/new-log-viewer/src/utils/data.ts
@@ -2,7 +2,6 @@ import {Nullable} from "../typings/common";
 import {clamp} from "./math";
 
 
-
 /**
  * Checks if `target` is bounded by the first and last value in a sorted array of numbers.
  *
@@ -135,9 +134,9 @@ const getMapValueWithNearestLessThanOrEqualKey = <T>(
 
 
 export {
-    isWithinBounds,
     clampWithinBounds,
     findNearestLessThanOrEqualElement,
     getMapKeyByValue,
     getMapValueWithNearestLessThanOrEqualKey,
+    isWithinBounds,
 };


### PR DESCRIPTION
# References
new-log-viewer series: https://github.com/y-scope/yscope-log-viewer/pull/45 https://github.com/y-scope/yscope-log-viewer/pull/46 https://github.com/y-scope/yscope-log-viewer/pull/48 https://github.com/y-scope/yscope-log-viewer/pull/51 https://github.com/y-scope/yscope-log-viewer/pull/52 https://github.com/y-scope/yscope-log-viewer/pull/53 https://github.com/y-scope/yscope-log-viewer/pull/54 https://github.com/y-scope/yscope-log-viewer/pull/55 https://github.com/y-scope/yscope-log-viewer/pull/56 https://github.com/y-scope/yscope-log-viewer/pull/59 https://github.com/y-scope/yscope-log-viewer/issues/60 https://github.com/y-scope/yscope-log-viewer/pull/61 https://github.com/y-scope/yscope-log-viewer/pull/62 https://github.com/y-scope/yscope-log-viewer/pull/63 https://github.com/y-scope/yscope-log-viewer/pull/66 https://github.com/y-scope/yscope-log-viewer/pull/67 https://github.com/y-scope/yscope-log-viewer/pull/68 https://github.com/y-scope/yscope-log-viewer/pull/69 https://github.com/y-scope/yscope-log-viewer/pull/70 https://github.com/y-scope/yscope-log-viewer/pull/71 https://github.com/y-scope/yscope-log-viewer/pull/72 https://github.com/y-scope/yscope-log-viewer/pull/73 https://github.com/y-scope/yscope-log-viewer/pull/74 https://github.com/y-scope/yscope-log-viewer/pull/76

# Description
The new event num cursor in #76 allows the front-end to request a page from the back-end using a log event number. When log events are filtered, the back-end must be able to search for that log event number in the filtered log event map. Specifically, the back-end response must return the closest existing log event in the map, and all the events on the page with the closest log event. 

For example consider the following filtered log event map (log event num are values), and a user setting of 3 events per page (simplified for example).
[2, 6, 8, 22, 123, 186]. 

If the front-end requests log-event number 146. The back end should be able to find and return closest log event (123), as well as send back decoded events 22, 123, 186 (i.e. the second page). 

This PR allows the back-end to find the index of the closest log event in the filtered map with binary search methods.

### Where methods will be used

The new search utils file exports two similar methods. The implement binary search to find the largest less than or equal index ("the closest log event") and  provide slightly different behaviour for edge cases.

`findLargestIdxLte` is useful for the example above, where we want to find the closest log event in the back-end. If the value requested is outside the range, for example, say the user requested event 10,000 in the example above, it would just return 186. 

`strictFindLargestIdxLte` is useful for the front-end to avoid unnecessary event num cursor requests. Say the user inputs a new log event number, this method can be used to find a `close` log event on the page (front-end stores all the log events on the current page). If there is a close log event, it will return an index, and the back-end request is never sent. It is strict in that if the log event is not on the page, it will let the caller know by retuning null, and a request can be sent.  

Note this methods are just implemented and they are not called anywhere yet.

# Validation performed
Tested basic functionality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for enhanced data retrieval in sorted arrays, including checks for value bounds and finding the largest index less than or equal to a specified value.
- **Documentation**
	- Comprehensive documentation provided for new functions, detailing parameters, return values, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->