### PR TITLE
new-log-viewer: Override JoyUI `fontFamily` and `radius` properties globally.

### DIFF
--- a/new-log-viewer/src/components/theme.tsx
+++ b/new-log-viewer/src/components/theme.tsx
@@ -56,9 +56,6 @@ const APP_THEME = extendTheme({
             },
         },
     },
-    focus: {
-        thickness: "1px",
-    },
     fontFamily: {
         body: "var(--ylv-ui-font-family)",
     },

--- a/new-log-viewer/src/components/theme.tsx
+++ b/new-log-viewer/src/components/theme.tsx
@@ -37,37 +37,10 @@ const APP_THEME = extendTheme({
             },
         },
     },
-    focus: {
-        default: {
-            outlineWidth: "3px",
-        },
-    },
-    fontFamily: {
-        body: "var(--ylv-ui-font-family)",
-    },
     components: {
-        JoyButton: {
-            styleOverrides: {
-                root: {
-                    borderRadius: "2px",
-                },
-            },
-        },
         JoySelect: {
             defaultProps: {
                 indicator: <KeyboardArrowDown/>,
-            },
-            styleOverrides: {
-                root: {
-                    borderRadius: "2px",
-                },
-            },
-        },
-        JoyInput: {
-            styleOverrides: {
-                root: {
-                    borderRadius: "2px",
-                },
             },
         },
         JoyFormControl: {
@@ -82,6 +55,23 @@ const APP_THEME = extendTheme({
                 }),
             },
         },
+    },
+    focus: {
+        default: {
+            outlineWidth: "3px",
+        },
+    },
+    fontFamily: {
+        body: "var(--ylv-ui-font-family)",
+    },
+    radius: {
+        /* eslint-disable sort-keys */
+        xs: "2px",
+        sm: "2px",
+        md: "2px",
+        lg: "2px",
+        xl: "2px",
+        /* eslint-enable sort-keys */
     },
 });
 

--- a/new-log-viewer/src/components/theme.tsx
+++ b/new-log-viewer/src/components/theme.tsx
@@ -57,9 +57,7 @@ const APP_THEME = extendTheme({
         },
     },
     focus: {
-        default: {
-            outlineWidth: "3px",
-        },
+        thickness: "1px",
     },
     fontFamily: {
         body: "var(--ylv-ui-font-family)",


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
new-log-viewer series: #45 #46 #48 #51 #52 #53 #54 #55 #56 #59 #60 #61 #62 #63 #66 #67 #68 #69 #70 #71 #72 #73 #74 #76 #77 #78 #79 #80 #81 #82

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Centralize border radius overrides with "radius" property in JoyUI theme config.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Launched debug server and verified component border radius matching expected overridden value. Used the browser debugger to "Inspect" individual elements to confirm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new border radius property for UI components, enhancing the visual consistency across various sizes.

- **Improvements**
  - Updated focus property for better accessibility, setting a more appropriate thickness.
  - Enhanced theme configuration for improved light and dark mode support, ensuring a cohesive user experience.

- **Bug Fixes**
  - Removed unnecessary style overrides from specific components, streamlining their appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->