### PR TITLE
feat(decoder): Add support for Structured CLP IR streams but without log-level filtering.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/icons-material": "^6.1.0",
         "@mui/joy": "^5.0.0-beta.48",
         "axios": "^1.7.2",
-        "clp-ffi-js": "^0.2.0",
+        "clp-ffi-js": "^0.3.0",
         "dayjs": "^1.11.11",
         "monaco-editor": "^0.50.0",
         "react": "^18.3.1",
@@ -4811,10 +4811,9 @@
       }
     },
     "node_modules/clp-ffi-js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/clp-ffi-js/-/clp-ffi-js-0.2.0.tgz",
-      "integrity": "sha512-4zGQ6Jh3y57LvO4dOD9YNi3LCpj+YWCPvqX1u8ugfp9RPnfIBjK7lilJa4jBWYsGq/Dhxe9mXb0i7WmqxuLotw==",
-      "license": "Apache-2.0"
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/clp-ffi-js/-/clp-ffi-js-0.3.0.tgz",
+      "integrity": "sha512-+jNULrIosKTSP9WbwDa9AcXzgHCN9W3/iZsQW6jjrzCRvqj9OKXwGzPKT1od6nDsSsKPNVqeBSmasGUWExtadA=="
     },
     "node_modules/clsx": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mui/icons-material": "^6.1.0",
     "@mui/joy": "^5.0.0-beta.48",
     "axios": "^1.7.2",
-    "clp-ffi-js": "^0.2.0",
+    "clp-ffi-js": "^0.3.0",
     "dayjs": "^1.11.11",
     "monaco-editor": "^0.50.0",
     "react": "^18.3.1",

--- a/src/services/LogFileManager/index.ts
+++ b/src/services/LogFileManager/index.ts
@@ -1,7 +1,7 @@
 /* eslint max-lines: ["error", 400] */
 import {
     Decoder,
-    DecoderOptionsType,
+    DecoderOptions,
 } from "../../typings/decoders";
 import {MAX_V8_STRING_LENGTH} from "../../typings/js";
 import {LogLevelFilter} from "../../typings/logs";
@@ -110,7 +110,7 @@ class LogFileManager {
     static async create (
         fileSrc: FileSrcType,
         pageSize: number,
-        decoderOptions: DecoderOptionsType,
+        decoderOptions: DecoderOptions,
         onQueryResults: (queryResults: QueryResults) => void,
     ): Promise<LogFileManager> {
         const {fileName, fileData} = await loadFile(fileSrc);
@@ -138,13 +138,13 @@ class LogFileManager {
     static async #initDecoder (
         fileName: string,
         fileData: Uint8Array,
-        decoderOptions: DecoderOptionsType
+        decoderOptions: DecoderOptions
     ): Promise<Decoder> {
         let decoder: Decoder;
         if (fileName.endsWith(".jsonl")) {
             decoder = new JsonlDecoder(fileData, decoderOptions);
         } else if (fileName.endsWith(".clp.zst")) {
-            decoder = await ClpIrDecoder.create(fileData);
+            decoder = await ClpIrDecoder.create(fileData, decoderOptions);
         } else {
             throw new Error(`No decoder supports ${fileName}`);
         }
@@ -161,7 +161,7 @@ class LogFileManager {
     /* Sets any formatter options that exist in the decoder's options.
      * @param options
      */
-    setFormatterOptions (options: DecoderOptionsType) {
+    setFormatterOptions (options: DecoderOptions) {
         this.#decoder.setFormatterOptions(options);
     }
 

--- a/src/services/MainWorker.ts
+++ b/src/services/MainWorker.ts
@@ -1,4 +1,5 @@
 import dayjs from "dayjs";
+import dayjsBigIntSupport from "dayjs/plugin/bigIntSupport";
 import dayjsTimezone from "dayjs/plugin/timezone";
 import dayjsUtc from "dayjs/plugin/utc";
 
@@ -17,6 +18,7 @@ import LogFileManager from "./LogFileManager";
 /* eslint-disable import/no-named-as-default-member */
 dayjs.extend(dayjsUtc);
 dayjs.extend(dayjsTimezone);
+dayjs.extend(dayjsBigIntSupport);
 /* eslint-enable import/no-named-as-default-member */
 
 /**

--- a/src/services/decoders/ClpIrDecoder.ts
+++ b/src/services/decoders/ClpIrDecoder.ts
@@ -1,32 +1,61 @@
-import clpFfiJsModuleInit, {ClpIrStreamReader} from "clp-ffi-js";
-
+import clpFfiJsModuleInit, {ClpStreamReader} from "../../../deps/ClpFfiJs-worker";
 import {Nullable} from "../../typings/common";
 import {
+    ClpIrDecoderOptions,
     Decoder,
     DecodeResultType,
     FilteredLogEventMap,
     LogEventCount,
 } from "../../typings/decoders";
-import {LogLevelFilter} from "../../typings/logs";
+import {JsonObject} from "../../typings/js";
+import {
+    LOG_LEVEL,
+    LogLevelFilter,
+} from "../../typings/logs";
+import LogbackFormatter from "../formatters/LogbackFormatter";
+import {
+    convertToDayjsTimestamp,
+    isJsonObject,
+} from "./JsonlDecoder/utils";
 
 
 class ClpIrDecoder implements Decoder {
-    #streamReader: ClpIrStreamReader;
+    #streamReader: ClpStreamReader;
 
-    constructor (streamReader: ClpIrStreamReader) {
+    #formatter: Nullable<LogbackFormatter>;
+
+    #logLevelKey: Nullable<string>;
+
+    constructor (streamReader: ClpStreamReader, formatter: Nullable<LogbackFormatter>, logLevelKey: Nullable<string>) {
         this.#streamReader = streamReader;
+        this.#formatter = formatter;
+        this.#logLevelKey = logLevelKey;
     }
 
     /**
      * Creates a new ClpIrDecoder instance.
      *
      * @param dataArray The input data array to be passed to the decoder.
+     * @param decoderOptions
      * @return The created ClpIrDecoder instance.
      */
-    static async create (dataArray: Uint8Array): Promise<ClpIrDecoder> {
+    static async create (
+        dataArray: Uint8Array,
+        decoderOptions: ClpIrDecoderOptions
+    ): Promise<ClpIrDecoder> {
         const module = await clpFfiJsModuleInit();
-        const streamReader = new module.ClpIrStreamReader(dataArray);
-        return new ClpIrDecoder(streamReader);
+        const streamReader = new module.ClpStreamReader(dataArray, decoderOptions);
+
+        let formatter: Nullable<LogbackFormatter> = null;
+        let logLevelKey: Nullable<string> = null;
+        if (
+            module.IRProtocolErrorCode.SUPPORTED === streamReader.getIrProtocolErrorCode()
+        ) {
+            formatter = new LogbackFormatter({formatString: decoderOptions.formatString});
+            ({logLevelKey} = decoderOptions);
+        }
+
+        return new ClpIrDecoder(streamReader, formatter, logLevelKey);
     }
 
     getEstimatedNumEvents (): number {
@@ -60,7 +89,36 @@ class ClpIrDecoder implements Decoder {
         endIdx: number,
         useFilter: boolean
     ): Nullable<DecodeResultType[]> {
-        return this.#streamReader.decodeRange(beginIdx, endIdx, useFilter);
+        const results = this.#streamReader.decodeRange(beginIdx, endIdx, useFilter);
+        if (null === this.#formatter) {
+            return results;
+        }
+        results.forEach((result) => {
+            const [message, timestamp] = result;
+            let fields: JsonObject = {};
+            try {
+                fields = JSON.parse(message) as JsonObject;
+                if (false === isJsonObject(fields)) {
+                    throw new Error("Unexpected non-object.");
+                } else if (null !== this.#logLevelKey) {
+                    const logLevel = fields[this.#logLevelKey];
+                    fields[this.#logLevelKey] = LOG_LEVEL[logLevel as LOG_LEVEL];
+                }
+            } catch (e) {
+                if (0 === message.length) {
+                    return;
+                }
+                console.error(e, message);
+            }
+
+            // @ts-expect-error `this.#formatter` is certainly non-null
+            result[0] = this.#formatter.formatLogEvent({
+                fields: fields,
+                timestamp: convertToDayjsTimestamp(timestamp),
+            });
+        });
+
+        return results;
     }
 }
 

--- a/src/services/decoders/ClpIrDecoder.ts
+++ b/src/services/decoders/ClpIrDecoder.ts
@@ -9,6 +9,7 @@ import {
     JsonlDecoderOptions,
     LogEventCount,
 } from "../../typings/decoders";
+import {Formatter} from "../../typings/formatters";
 import {JsonObject} from "../../typings/js";
 import {
     LOG_LEVEL,
@@ -31,7 +32,7 @@ class ClpIrDecoder implements Decoder {
 
     #streamType: CLP_IR_STREAM_TYPE;
 
-    #formatter: Nullable<LogbackFormatter>;
+    #formatter: Nullable<Formatter>;
 
     constructor (
         streamType: CLP_IR_STREAM_TYPE,

--- a/src/services/decoders/ClpIrDecoder.ts
+++ b/src/services/decoders/ClpIrDecoder.ts
@@ -4,7 +4,7 @@ import {Dayjs} from "dayjs";
 import {Nullable} from "../../typings/common";
 import {
     Decoder,
-    DecodeResultType,
+    DecodeResult,
     DecoderOptions,
     FilteredLogEventMap,
     LogEventCount,
@@ -95,8 +95,8 @@ class ClpIrDecoder implements Decoder {
         beginIdx: number,
         endIdx: number,
         useFilter: boolean
-    ): Nullable<DecodeResultType[]> {
-        const results: DecodeResultType[] =
+    ): Nullable<DecodeResult[]> {
+        const results: DecodeResult[] =
             this.#streamReader.decodeRange(beginIdx, endIdx, useFilter);
 
         if (this.#streamType === CLP_IR_STREAM_TYPE.UNSTRUCTURED) {

--- a/src/services/decoders/ClpIrDecoder.ts
+++ b/src/services/decoders/ClpIrDecoder.ts
@@ -45,10 +45,11 @@ class ClpIrDecoder implements Decoder {
 
     /**
      * Creates a new ClpIrDecoder instance.
+     * NOTE: `decoderOptions` only affects decode results if the stream type is
+     * {@link CLP_IR_STREAM_TYPE.STRUCTURED}.
      *
      * @param dataArray The input data array to be passed to the decoder.
-     * @param decoderOptions The options are only effective if the stream type is
-     * {@link CLP_IR_STREAM_TYPE.STRUCTURED}.
+     * @param decoderOptions
      * @return The created ClpIrDecoder instance.
      */
     static async create (

--- a/src/services/decoders/ClpIrDecoder.ts
+++ b/src/services/decoders/ClpIrDecoder.ts
@@ -100,16 +100,22 @@ class ClpIrDecoder implements Decoder {
         const results: DecodeResult[] =
             this.#streamReader.decodeRange(beginIdx, endIdx, useFilter);
 
-        if (this.#streamType === CLP_IR_STREAM_TYPE.UNSTRUCTURED) {
+        if (null === this.#formatter) {
+            if (this.#streamType === CLP_IR_STREAM_TYPE.STRUCTURED) {
+                // eslint-disable-next-line no-warning-comments
+                // TODO: Revisit when we allow displaying structured logs without a formatter.
+                console.error("Formatter is not set for structured logs.");
+            }
+
             return results;
         }
 
-        results.forEach((result) => {
+        for (const r of results) {
             const [
                 message,
                 timestamp,
                 level,
-            ] = result;
+            ] = r;
             const dayJsTimestamp: Dayjs = convertToDayjsTimestamp(timestamp);
             let fields: JsonObject = {};
 
@@ -122,14 +128,12 @@ class ClpIrDecoder implements Decoder {
                 console.error(e, message);
             }
 
-            // `this.#formatter` has been null-checked at the method entry.
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            result[0] = this.#formatter!.formatLogEvent({
+            r[0] = this.#formatter.formatLogEvent({
                 fields: fields,
                 level: level,
                 timestamp: dayJsTimestamp,
             });
-        });
+        }
 
         return results;
     }

--- a/src/services/decoders/ClpIrDecoder.ts
+++ b/src/services/decoders/ClpIrDecoder.ts
@@ -98,7 +98,7 @@ class ClpIrDecoder implements Decoder {
         endIdx: number,
         useFilter: boolean
     ): Nullable<DecodeResultType[]> {
-        const results = this.#streamReader.decodeRange(beginIdx, endIdx, useFilter);
+        const results: DecodeResultType[] = this.#streamReader.decodeRange(beginIdx, endIdx, useFilter);
         if (this.#streamType === CLP_IR_STREAM_TYPE.UNSTRUCTURED) {
             return results;
         }

--- a/src/services/decoders/JsonlDecoder/index.ts
+++ b/src/services/decoders/JsonlDecoder/index.ts
@@ -5,7 +5,7 @@ import {
     Decoder,
     DecodeResultType,
     FilteredLogEventMap,
-    JsonlDecoderOptionsType,
+    JsonlDecoderOptions,
     LogEventCount,
 } from "../../../typings/decoders";
 import {Formatter} from "../../../typings/formatters";
@@ -25,7 +25,7 @@ import {
 
 
 /**
- * A decoder for JSONL (JSON lines) files that contain log events. See `JsonlDecoderOptionsType` for
+ * A decoder for JSONL (JSON lines) files that contain log events. See `JsonlDecoderOptions` for
  * properties that are specific to log events (compared to generic JSON records).
  */
 class JsonlDecoder implements Decoder {
@@ -49,7 +49,7 @@ class JsonlDecoder implements Decoder {
      * @param dataArray
      * @param decoderOptions
      */
-    constructor (dataArray: Uint8Array, decoderOptions: JsonlDecoderOptionsType) {
+    constructor (dataArray: Uint8Array, decoderOptions: JsonlDecoderOptions) {
         this.#dataArray = dataArray;
         this.#logLevelKey = decoderOptions.logLevelKey;
         this.#timestampKey = decoderOptions.timestampKey;
@@ -81,7 +81,7 @@ class JsonlDecoder implements Decoder {
         };
     }
 
-    setFormatterOptions (options: JsonlDecoderOptionsType): boolean {
+    setFormatterOptions (options: JsonlDecoderOptions): boolean {
         this.#formatter = new LogbackFormatter({formatString: options.formatString});
 
         return true;

--- a/src/services/decoders/JsonlDecoder/index.ts
+++ b/src/services/decoders/JsonlDecoder/index.ts
@@ -4,8 +4,8 @@ import {Nullable} from "../../../typings/common";
 import {
     Decoder,
     DecodeResultType,
+    DecoderOptions,
     FilteredLogEventMap,
-    JsonlDecoderOptions,
     LogEventCount,
 } from "../../../typings/decoders";
 import {Formatter} from "../../../typings/formatters";
@@ -25,7 +25,7 @@ import {
 
 
 /**
- * A decoder for JSONL (JSON lines) files that contain log events. See `JsonlDecoderOptions` for
+ * A decoder for JSONL (JSON lines) files that contain log events. See `DecoderOptions` for
  * properties that are specific to log events (compared to generic JSON records).
  */
 class JsonlDecoder implements Decoder {
@@ -49,7 +49,7 @@ class JsonlDecoder implements Decoder {
      * @param dataArray
      * @param decoderOptions
      */
-    constructor (dataArray: Uint8Array, decoderOptions: JsonlDecoderOptions) {
+    constructor (dataArray: Uint8Array, decoderOptions: DecoderOptions) {
         this.#dataArray = dataArray;
         this.#logLevelKey = decoderOptions.logLevelKey;
         this.#timestampKey = decoderOptions.timestampKey;
@@ -81,7 +81,7 @@ class JsonlDecoder implements Decoder {
         };
     }
 
-    setFormatterOptions (options: JsonlDecoderOptions): boolean {
+    setFormatterOptions (options: DecoderOptions): boolean {
         this.#formatter = new LogbackFormatter({formatString: options.formatString});
 
         return true;

--- a/src/services/decoders/JsonlDecoder/index.ts
+++ b/src/services/decoders/JsonlDecoder/index.ts
@@ -3,7 +3,7 @@ import {Dayjs} from "dayjs";
 import {Nullable} from "../../../typings/common";
 import {
     Decoder,
-    DecodeResultType,
+    DecodeResult,
     DecoderOptions,
     FilteredLogEventMap,
     LogEventCount,
@@ -91,7 +91,7 @@ class JsonlDecoder implements Decoder {
         beginIdx: number,
         endIdx: number,
         useFilter: boolean,
-    ): Nullable<DecodeResultType[]> {
+    ): Nullable<DecodeResult[]> {
         if (useFilter && null === this.#filteredLogEventMap) {
             return null;
         }
@@ -104,7 +104,7 @@ class JsonlDecoder implements Decoder {
             return null;
         }
 
-        const results: DecodeResultType[] = [];
+        const results: DecodeResult[] = [];
         for (let i = beginIdx; i < endIdx; i++) {
             // Explicit cast since typescript thinks `#filteredLogEventMap[i]` can be undefined, but
             // it shouldn't be since we performed a bounds check at the beginning of the method.
@@ -204,12 +204,12 @@ class JsonlDecoder implements Decoder {
     }
 
     /**
-     * Decodes a log event into a `DecodeResultType`.
+     * Decodes a log event into a `DecodeResult`.
      *
      * @param logEventIdx
      * @return The decoded log event.
      */
-    #decodeLogEvent = (logEventIdx: number): DecodeResultType => {
+    #decodeLogEvent = (logEventIdx: number): DecodeResult => {
         let timestamp: number;
         let message: string;
         let logLevel: LOG_LEVEL;

--- a/src/services/decoders/JsonlDecoder/utils.ts
+++ b/src/services/decoders/JsonlDecoder/utils.ts
@@ -53,12 +53,13 @@ const convertToLogLevelValue = (field: JsonValue | undefined): LOG_LEVEL => {
  * - the timestamp's value is an unsupported type.
  * - the timestamp's value is not a valid dayjs timestamp.
  */
-const convertToDayjsTimestamp = (field: JsonValue | undefined): dayjs.Dayjs => {
+const convertToDayjsTimestamp = (field: JsonValue | bigint | undefined): dayjs.Dayjs => {
     // If the field is an invalid type, then set the timestamp to `INVALID_TIMESTAMP_VALUE`.
     // NOTE: dayjs surprisingly thinks `undefined` is a valid date. See
     // https://day.js.org/docs/en/parse/now#docsNav
     if (("string" !== typeof field &&
-        "number" !== typeof field) ||
+        "number" !== typeof field &&
+        "bigint" !== typeof field) ||
         "undefined" === typeof field
     ) {
         // `INVALID_TIMESTAMP_VALUE` is a valid dayjs date. Another potential option is

--- a/src/typings/config.ts
+++ b/src/typings/config.ts
@@ -1,4 +1,4 @@
-import {JsonlDecoderOptionsType} from "./decoders";
+import {JsonlDecoderOptions} from "./decoders";
 import {TAB_NAME} from "./tab";
 
 
@@ -27,7 +27,7 @@ enum LOCAL_STORAGE_KEY {
 /* eslint-enable @typescript-eslint/prefer-literal-enum-member */
 
 type ConfigMap = {
-    [CONFIG_KEY.DECODER_OPTIONS]: JsonlDecoderOptionsType,
+    [CONFIG_KEY.DECODER_OPTIONS]: JsonlDecoderOptions,
     [CONFIG_KEY.INITIAL_TAB_NAME]: TAB_NAME,
     [CONFIG_KEY.THEME]: THEME_NAME,
     [CONFIG_KEY.PAGE_SIZE]: number,

--- a/src/typings/config.ts
+++ b/src/typings/config.ts
@@ -1,4 +1,4 @@
-import {JsonlDecoderOptions} from "./decoders";
+import {DecoderOptions} from "./decoders";
 import {TAB_NAME} from "./tab";
 
 
@@ -27,7 +27,7 @@ enum LOCAL_STORAGE_KEY {
 /* eslint-enable @typescript-eslint/prefer-literal-enum-member */
 
 type ConfigMap = {
-    [CONFIG_KEY.DECODER_OPTIONS]: JsonlDecoderOptions,
+    [CONFIG_KEY.DECODER_OPTIONS]: DecoderOptions,
     [CONFIG_KEY.INITIAL_TAB_NAME]: TAB_NAME,
     [CONFIG_KEY.THEME]: THEME_NAME,
     [CONFIG_KEY.PAGE_SIZE]: number,

--- a/src/typings/decoders.ts
+++ b/src/typings/decoders.ts
@@ -8,31 +8,15 @@ interface LogEventCount {
 }
 
 /**
- * Options for the JSONL decoder.
- *
  * @property formatString The format string to use to serialize records as plain text.
  * @property logLevelKey The key of the kv-pair that contains the log level in every record.
  * @property timestampKey The key of the kv-pair that contains the timestamp in every record.
  */
-interface JsonlDecoderOptions {
+interface DecoderOptions {
     formatString: string,
     logLevelKey: string,
     timestampKey: string,
 }
-
-/**
- * Options for the Structured CLP IR decoder.
- */
-interface StructuredClpIrDecoderOptions extends JsonlDecoderOptions {
-}
-
-/**
- * Options for the CLP IR decoder. Currently, those options are only effective if the stream is
- * Structured IR.
- */
-type ClpIrDecoderOptions = StructuredClpIrDecoderOptions;
-
-type DecoderOptions = JsonlDecoderOptions | ClpIrDecoderOptions;
 
 /**
  * Type of the decoded log event. We use an array rather than object so that it's easier to return
@@ -118,11 +102,9 @@ interface Decoder {
 
 export type {
     ActiveLogCollectionEventIdx,
-    ClpIrDecoderOptions,
     Decoder,
     DecodeResultType,
     DecoderOptions,
     FilteredLogEventMap,
-    JsonlDecoderOptions,
     LogEventCount,
 };

--- a/src/typings/decoders.ts
+++ b/src/typings/decoders.ts
@@ -14,13 +14,25 @@ interface LogEventCount {
  * @property logLevelKey The key of the kv-pair that contains the log level in every record.
  * @property timestampKey The key of the kv-pair that contains the timestamp in every record.
  */
-interface JsonlDecoderOptionsType {
+interface JsonlDecoderOptions {
     formatString: string,
     logLevelKey: string,
     timestampKey: string,
 }
 
-type DecoderOptionsType = JsonlDecoderOptionsType;
+/**
+ * Options for the Structured CLP IR decoder.
+ */
+interface StructuredClpIrDecoderOptions extends JsonlDecoderOptions {
+}
+
+/**
+ * Options for the CLP IR decoder. Currently, those options are only effective if the stream is
+ * Structured IR.
+ */
+type ClpIrDecoderOptions = StructuredClpIrDecoderOptions;
+
+type DecoderOptions = JsonlDecoderOptions | ClpIrDecoderOptions;
 
 /**
  * Type of the decoded log event. We use an array rather than object so that it's easier to return
@@ -85,7 +97,7 @@ interface Decoder {
      * @param options
      * @return Whether the options were successfully set.
      */
-    setFormatterOptions(options: DecoderOptionsType): boolean;
+    setFormatterOptions(options: DecoderOptions): boolean;
 
     /**
      * Decodes log events in the range `[beginIdx, endIdx)` of the filtered or unfiltered
@@ -106,10 +118,11 @@ interface Decoder {
 
 export type {
     ActiveLogCollectionEventIdx,
+    ClpIrDecoderOptions,
     Decoder,
     DecodeResultType,
-    DecoderOptionsType,
+    DecoderOptions,
     FilteredLogEventMap,
-    JsonlDecoderOptionsType,
+    JsonlDecoderOptions,
     LogEventCount,
 };

--- a/src/typings/decoders.ts
+++ b/src/typings/decoders.ts
@@ -27,7 +27,7 @@ interface DecoderOptions {
  * @property level
  * @property number
  */
-type DecodeResultType = [string, number, number, number];
+type DecodeResult = [string, bigint, number, number];
 
 /**
  * Mapping between an index in the filtered log events collection to an index in the unfiltered log
@@ -97,13 +97,13 @@ interface Decoder {
         beginIdx: number,
         endIdx: number,
         useFilter: boolean
-    ): Nullable<DecodeResultType[]>;
+    ): Nullable<DecodeResult[]>;
 }
 
 export type {
     ActiveLogCollectionEventIdx,
     Decoder,
-    DecodeResultType,
+    DecodeResult,
     DecoderOptions,
     FilteredLogEventMap,
     LogEventCount,

--- a/src/typings/worker.ts
+++ b/src/typings/worker.ts
@@ -1,7 +1,7 @@
 import {Nullable} from "./common";
 import {
     ActiveLogCollectionEventIdx,
-    DecoderOptionsType,
+    DecoderOptions,
 } from "./decoders";
 import {
     LOG_LEVEL,
@@ -89,7 +89,7 @@ type WorkerReqMap = {
         fileSrc: FileSrcType,
         pageSize: number,
         cursor: CursorType,
-        decoderOptions: DecoderOptionsType
+        decoderOptions: DecoderOptions
     },
     [WORKER_REQ_CODE.LOAD_PAGE]: {
         cursor: CursorType,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,7 +6,7 @@ import {
     LOCAL_STORAGE_KEY,
     THEME_NAME,
 } from "../typings/config";
-import {DecoderOptionsType} from "../typings/decoders";
+import {DecoderOptions} from "../typings/decoders";
 import {TAB_NAME} from "../typings/tab";
 
 
@@ -131,7 +131,7 @@ const getConfig = <T extends CONFIG_KEY>(key: T): ConfigMap[T] => {
                 timestampKey: window.localStorage.getItem(
                     LOCAL_STORAGE_KEY.DECODER_OPTIONS_TIMESTAMP_KEY
                 ),
-            } as DecoderOptionsType;
+            } as DecoderOptions;
             break;
         case CONFIG_KEY.INITIAL_TAB_NAME:
             value = window.localStorage.getItem(LOCAL_STORAGE_KEY.INITIAL_TAB_NAME);


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
https://github.com/y-scope/clp-ffi-js/releases/tag/v0.3.0 added support for decoding Structured CLP IR streams but without log-level filtering. In the decoded results returned by the reader, the message contains a complete JSON-serialized log event. Before display the log events in the log viewer, we can use the existing formatter for JSON logs to format the log events to improve readbility.

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Update `clp-ffi-js` to `0.3.0`.
2. Add Structured CLP IR stream handling into ClpIrDecoder but without log-level filtering.


# Validation performed
<!-- What tests and validation you performed on the change -->
1. Referred to y-scope/clp-ffi-js/pull/30 , loaded the [test-irv2.clp.zip](https://github.com/user-attachments/files/17658298/test-irv2.clp.zip) file in the browser and observed the 1000 log events displayed as formatted messages in the readonly editor.
   <img width="1080" alt="image" src="https://github.com/user-attachments/assets/fa8d1355-746d-431c-bb1e-f1841315b884">
2. Referred to y-scope/clp-ffi-js/pull/30 , sanitize tested the "Zstd-compressed CLP IR stream files with older versions".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated dependency for `clp-ffi-js` to enhance performance and stability.
	- Added support for `bigint` in timestamp handling for improved data processing.

- **Improvements**
	- Enhanced flexibility in decoder options across multiple classes, allowing for better customization.
	- Improved handling of different stream types in the `ClpIrDecoder` for more robust data parsing.

- **Bug Fixes**
	- Corrected type definitions to ensure consistency across the application, reducing potential errors.

- **Documentation**
	- Updated comments and documentation to reflect changes in type definitions and options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206305234958557