### PR TITLE
new-log-viewer: Disable pointer events for log level tooltips to prevent underlying checkbox from being blocked (fixes #90).

### DIFF
--- a/new-log-viewer/src/components/StatusBar/LogLevelSelect/index.css
+++ b/new-log-viewer/src/components/StatusBar/LogLevelSelect/index.css
@@ -18,4 +18,11 @@
 .log-level-select-listbox {
     /* Disallow width auto-resizing with the `Select` button. */
     max-width: 0;
+    margin-bottom: -3px !important;
+}
+
+.log-level-select-option-text-tooltip {
+    /* Disable pointer events to prevent tooltips from blocking interaction with underlying
+      elements. */
+    pointer-events: none;
 }

--- a/new-log-viewer/src/components/StatusBar/LogLevelSelect/index.css
+++ b/new-log-viewer/src/components/StatusBar/LogLevelSelect/index.css
@@ -18,7 +18,6 @@
 .log-level-select-listbox {
     /* Disallow width auto-resizing with the `Select` button. */
     max-width: 0;
-    margin-bottom: -3px !important;
 }
 
 .log-level-select-option-text-tooltip {

--- a/new-log-viewer/src/components/StatusBar/LogLevelSelect/index.tsx
+++ b/new-log-viewer/src/components/StatusBar/LogLevelSelect/index.tsx
@@ -96,6 +96,7 @@ const LogSelectOption = ({
             </ListItemDecorator>
             <Tooltip
                 placement={"left"}
+                slotProps={{root: {className: "log-level-select-option-text-tooltip"}}}
                 title={
                     <Stack
                         alignItems={"center"}


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
Fixes #90 
new-log-viewer series: #45 #46 #48 #51 #52 #53 #54 #55 #56 #59 #60 #61 #62 #63 #66 #67 #68 #69 #70 #71 #72 #73 #74 #76 #77 #78 #79 #80 #81 #82 #83 #84 #89

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Disable pointer events for log level tooltips to prevent underlying checkbox from being blocked.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Repeated the steps in the #90 issue description and observed the select option text tooltip disappeared once the mouse cursor left the option text.
   ![image](https://github.com/user-attachments/assets/1329ac57-accb-4c0d-9e83-7827fa45f117)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new tooltip styling for log level options to enhance user experience.
  
- **Bug Fixes**
	- Adjusted styles for the log level select component to resolve positioning issues and improve layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->