### PR TITLE
new-log-viewer: Persist active tab across sessions.

### DIFF
--- a/new-log-viewer/src/components/CentralContainer/Sidebar/index.tsx
+++ b/new-log-viewer/src/components/CentralContainer/Sidebar/index.tsx
@@ -1,10 +1,17 @@
 import {
     useCallback,
+    useEffect,
+    useMemo,
     useRef,
     useState,
 } from "react";
 
+import {CONFIG_KEY} from "../../../typings/config";
 import {TAB_NAME} from "../../../typings/tab";
+import {
+    getConfig,
+    setConfig,
+} from "../../../utils/config";
 import ResizeHandle from "./ResizeHandle";
 import SidebarTabs from "./SidebarTabs";
 
@@ -42,8 +49,8 @@ const setPanelWidth = (newValue: number) => {
  * @return
  */
 const Sidebar = () => {
-    const [activeTabName, setActiveTabName] = useState<TAB_NAME>(TAB_NAME.FILE_INFO);
-
+    const initialTabName = useMemo(() => getConfig(CONFIG_KEY.INITIAL_TAB_NAME), []);
+    const [activeTabName, setActiveTabName] = useState<TAB_NAME>(initialTabName);
     const tabListRef = useRef<HTMLDivElement>(null);
 
     const handleActiveTabNameChange = useCallback((tabName: TAB_NAME) => {
@@ -53,14 +60,15 @@ const Sidebar = () => {
             return;
         }
 
+        let newTabName = tabName;
+        let newPanelWidth = PANEL_DEFAULT_WIDTH_IN_PIXELS;
         if (activeTabName === tabName) {
-            setActiveTabName(TAB_NAME.NONE);
-            setPanelWidth(tabListRef.current.clientWidth);
-
-            return;
+            newTabName = TAB_NAME.NONE;
+            newPanelWidth = tabListRef.current.clientWidth;
         }
-        setActiveTabName(tabName);
-        setPanelWidth(PANEL_DEFAULT_WIDTH_IN_PIXELS);
+        setActiveTabName(newTabName);
+        setConfig({key: CONFIG_KEY.INITIAL_TAB_NAME, value: newTabName});
+        setPanelWidth(newPanelWidth);
     }, [activeTabName]);
 
     const handleResizeHandleRelease = useCallback(() => {
@@ -91,6 +99,18 @@ const Sidebar = () => {
             setPanelWidth(resizeHandlePosition);
         }
     }, []);
+
+    // On initialization, do not show panel if there is no active tab.
+    useEffect(() => {
+        if (null === tabListRef.current) {
+            console.error("Unexpected null tabListRef.current");
+
+            return;
+        }
+        if (TAB_NAME.NONE === initialTabName) {
+            setPanelWidth(tabListRef.current.clientWidth);
+        }
+    }, [initialTabName]);
 
     return (
         <div className={"sidebar-tabs-container"}>

--- a/new-log-viewer/src/typings/config.ts
+++ b/new-log-viewer/src/typings/config.ts
@@ -1,4 +1,5 @@
 import {JsonlDecoderOptionsType} from "./decoders";
+import {TAB_NAME} from "./tab";
 
 
 enum THEME_NAME {
@@ -9,6 +10,7 @@ enum THEME_NAME {
 
 enum CONFIG_KEY {
     DECODER_OPTIONS = "decoderOptions",
+    INITIAL_TAB_NAME = "initialTabName",
     THEME = "theme",
     PAGE_SIZE = "pageSize",
 }
@@ -18,6 +20,7 @@ enum LOCAL_STORAGE_KEY {
     DECODER_OPTIONS_FORMAT_STRING = `${CONFIG_KEY.DECODER_OPTIONS}/formatString`,
     DECODER_OPTIONS_LOG_LEVEL_KEY = `${CONFIG_KEY.DECODER_OPTIONS}/logLevelKey`,
     DECODER_OPTIONS_TIMESTAMP_KEY = `${CONFIG_KEY.DECODER_OPTIONS}/timestampKey`,
+    INITIAL_TAB_NAME = CONFIG_KEY.INITIAL_TAB_NAME,
     THEME = CONFIG_KEY.THEME,
     PAGE_SIZE = CONFIG_KEY.PAGE_SIZE,
 }
@@ -25,6 +28,7 @@ enum LOCAL_STORAGE_KEY {
 
 type ConfigMap = {
     [CONFIG_KEY.DECODER_OPTIONS]: JsonlDecoderOptionsType,
+    [CONFIG_KEY.INITIAL_TAB_NAME]: TAB_NAME,
     [CONFIG_KEY.THEME]: THEME_NAME,
     [CONFIG_KEY.PAGE_SIZE]: number,
 };

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -44,6 +44,9 @@ const testConfig = ({key, value}: ConfigUpdate): Nullable<string> => {
                 result = "Decoder options cannot be empty.";
             }
             break;
+        case CONFIG_KEY.INITIAL_TAB_NAME:
+            // This config option is not intended for direct user input.
+            break;
         case CONFIG_KEY.THEME:
             throw new Error(`"${key}" cannot be managed using these utilities.`);
         case CONFIG_KEY.PAGE_SIZE:

--- a/new-log-viewer/src/utils/config.ts
+++ b/new-log-viewer/src/utils/config.ts
@@ -7,6 +7,7 @@ import {
     THEME_NAME,
 } from "../typings/config";
 import {DecoderOptionsType} from "../typings/decoders";
+import {TAB_NAME} from "../typings/tab";
 
 
 const MAX_PAGE_SIZE = 1_000_000;
@@ -21,6 +22,7 @@ const CONFIG_DEFAULT: ConfigMap = Object.freeze({
         logLevelKey: "log.level",
         timestampKey: "@timestamp",
     },
+    [CONFIG_KEY.INITIAL_TAB_NAME]: TAB_NAME.FILE_INFO,
     [CONFIG_KEY.THEME]: THEME_NAME.SYSTEM,
     [CONFIG_KEY.PAGE_SIZE]: 10_000,
 });
@@ -88,6 +90,9 @@ const setConfig = ({key, value}: ConfigUpdate): Nullable<string> => {
                 value.timestampKey
             );
             break;
+        case CONFIG_KEY.INITIAL_TAB_NAME:
+            window.localStorage.setItem(CONFIG_KEY.INITIAL_TAB_NAME, value.toString());
+            break;
         case CONFIG_KEY.THEME:
             throw new Error(`"${key}" cannot be managed using these utilities.`);
         case CONFIG_KEY.PAGE_SIZE:
@@ -123,6 +128,9 @@ const getConfig = <T extends CONFIG_KEY>(key: T): ConfigMap[T] => {
                     LOCAL_STORAGE_KEY.DECODER_OPTIONS_TIMESTAMP_KEY
                 ),
             } as DecoderOptionsType;
+            break;
+        case CONFIG_KEY.INITIAL_TAB_NAME:
+            value = window.localStorage.getItem(LOCAL_STORAGE_KEY.INITIAL_TAB_NAME);
             break;
         case CONFIG_KEY.THEME:
             throw new Error(`"${key}" cannot be managed using these utilities.`);


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
new-log-viewer series: #45 #46 #48 #51 #52 #53 #54 #55 #56 #59 #60 #61 #62 #63 #66 #67 #68 #69 #70 #71 #72 #73 #74 #76 #77 #78 #79 #80 #81 #82 #83 #84 #89 #91

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Add config option "INITIAL_TAB_NAME" into the config utilities.
2. Use the config value as the initial tab name.
3. Update the config value whenever tab change happens.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Cleared browser caches (especially the data in localStorage).
2. Started debug server as specified in #46.
3. Observed the panel was expanded initially with the "File info" tab being active.
4. Clicked the "File info" tab button to collapse the panel.
5. Refreshed the browser page so that the log viewer app got reloaded. Observed that the panel was collapsed when the app was loaded.
6. Clicked the "File info" tab button to expand the panel and activate the tab.
7. Refreshed the browser page so that the log viewer app got reloaded. Observed that the panel was expanded initially with the "File info" tab being active when the app was loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced sidebar functionality with dynamic tab management based on configuration.
	- Improved configuration management for initial tab settings.

- **Bug Fixes**
	- Streamlined logic for handling active tab and panel width.

- **Documentation**
	- Updated configuration keys for better clarity and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->