### PR TITLE
new-log-viewer: In the menubar, show file name with a centered ellipsis when the name overflows (Fixes #97).

### DIFF
--- a/new-log-viewer/src/components/MenuBar/PageNumInput.css
+++ b/new-log-viewer/src/components/MenuBar/PageNumInput.css
@@ -1,3 +1,9 @@
+.page-num-input {
+    /* Ensures the content within the element does not wrap, preventing visual overflow when
+      adjacent elements under the same parent container attempt to take up space. */
+    white-space: nowrap;
+}
+
 .page-num-input input::-webkit-outer-spin-button,
 .page-num-input input::-webkit-inner-spin-button {
     margin: 0;

--- a/new-log-viewer/src/components/MenuBar/index.css
+++ b/new-log-viewer/src/components/MenuBar/index.css
@@ -14,7 +14,7 @@
 .menu-bar-logo-container {
     display: flex;
     justify-content: center;
-    width: 48px;
+    min-width: 48px;
     height: var(--ylv-status-bar-height);
 }
 
@@ -22,7 +22,20 @@
     font-size: 24px !important;
 }
 
-.menu-bar-filename {
+.menu-bar-filename-container {
+    overflow-x: hidden;
+    display: flex;
     flex-grow: 1;
-    padding-left: 10px;
+    padding-inline: 0.75rem !important;
+}
+
+.menu-bar-filename-left-split {
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+}
+
+.menu-bar-filename-right-split {
+    overflow-x: hidden;
+    display: flex !important;
+    justify-content: flex-end;
 }

--- a/new-log-viewer/src/components/MenuBar/index.tsx
+++ b/new-log-viewer/src/components/MenuBar/index.tsx
@@ -64,10 +64,16 @@ const MenuBar = () => {
                     className={"menu-bar-filename-container"}
                     title={fileName}
                 >
-                    <Typography className={"menu-bar-filename-left-split"}>
+                    <Typography
+                        className={"menu-bar-filename-left-split"}
+                        level={"body-md"}
+                    >
                         {fileName.slice(0, fileName.length / 2)}
                     </Typography>
-                    <Typography className={"menu-bar-filename-right-split"}>
+                    <Typography
+                        className={"menu-bar-filename-right-split"}
+                        level={"body-md"}
+                    >
                         {fileName.slice(fileName.length / 2)}
                     </Typography>
                 </Box>

--- a/new-log-viewer/src/components/MenuBar/index.tsx
+++ b/new-log-viewer/src/components/MenuBar/index.tsx
@@ -1,6 +1,7 @@
 import {useContext} from "react";
 
 import {
+    Box,
     Divider,
     IconButton,
     Sheet,
@@ -59,12 +60,17 @@ const MenuBar = () => {
                 </Tooltip>
                 <Divider orientation={"vertical"}/>
 
-                <Typography
-                    className={"menu-bar-filename"}
-                    level={"body-md"}
+                <Box
+                    className={"menu-bar-filename-container"}
+                    title={fileName}
                 >
-                    {fileName}
-                </Typography>
+                    <Typography className={"menu-bar-filename-left-split"}>
+                        {fileName.slice(0, fileName.length / 2)}
+                    </Typography>
+                    <Typography className={"menu-bar-filename-right-split"}>
+                        {fileName.slice(fileName.length / 2)}
+                    </Typography>
+                </Box>
 
                 <Divider orientation={"vertical"}/>
                 <NavigationBar/>


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
Fixes #97
new-log-viewer series: #45 #46 #48 #51 #52 #53 #54 #55 #56 #59 #60 #61 #62 #63 #66 #67 #68 #69 #70 #71 #72 #73 #74 #76 #77 #78 #79 #80 #81 #82 #83 #84 #89 #91 #93 #94 #96


# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Show file name with centered ellipsis in the menubar when the name overflows.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Repeated the reproduction steps in the #97 issue report and observed now the menu bar is no longer getting overflowed.
2. Resized the window in width and observed that the beginning and ending text of the file name was always visible, with the middle part showing more / less characters as the window was resizing. When the menu bar is not long enough to hold the full file name, an ellipsis showed in the middle; when the file name fully fits, the ellipsis is gone and all text was shown without any gap in between.
   ![image](https://github.com/user-attachments/assets/155319b7-4ed2-4070-b9f3-4e8212efb28b)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new CSS class for page number input to prevent content wrapping.
	- Added new classes for improved layout management of filename segments in the MenuBar component.

- **Improvements**
	- Enhanced layout and styling of the MenuBar component for better responsiveness.
	- Updated file name display logic in the MenuBar for improved visual representation.

- **Bug Fixes**
	- Adjusted overflow handling for filename segments to prevent visual overflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->