### PR TITLE
new-log-viewer: Fix filename wrapping and overflow in menu bar for filenames with hyphens on narrow windows (fixes #99). 

### DIFF
--- a/new-log-viewer/src/components/MenuBar/index.css
+++ b/new-log-viewer/src/components/MenuBar/index.css
@@ -26,7 +26,10 @@
     overflow-x: hidden;
     display: flex;
     flex-grow: 1;
+
     padding-inline: 0.75rem !important;
+
+    white-space: nowrap;
 }
 
 .menu-bar-filename-left-split {


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
Fixes #99
new-log-viewer series: #45 #46 #48 #51 #52 #53 #54 #55 #56 #59 #60 #61 #62 #63 #66 #67 #68 #69 #70 #71 #72 #73 #74 #76 #77 #78 #79 #80 #81 #82 #83 #84 #89 #91 #93 #94 #96 #98 

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Add `white-space: nowrap;` to `.menu-bar-filename-container`.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Repeated the production steps in the issue report and observed no overflow happened.
   ![image](https://github.com/user-attachments/assets/671415a8-ea38-4e5e-8a14-d99800527b07)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced layout and text handling in the MenuBar component with improved padding and white-space properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->