### PR TITLE
Remove spin buttons on number input fields in Firefox (fixes #103).

### DIFF
--- a/src/components/MenuBar/PageNumInput.css
+++ b/src/components/MenuBar/PageNumInput.css
@@ -4,10 +4,17 @@
     white-space: nowrap;
 }
 
-.page-num-input input::-webkit-outer-spin-button,
-.page-num-input input::-webkit-inner-spin-button {
+/* Remove the spin buttons (up/down arrows) on number input fields for WebKit-based browsers.
+   NOTE: This approach does not work for Firefox Browser. See the next rule for mitigation. */
+.page-num-input input[type="number"]::-webkit-outer-spin-button,
+.page-num-input input[type="number"]::-webkit-inner-spin-button {
     margin: 0;
     appearance: none;
+}
+
+/* Show number input fields as `textfield` to remove the spin buttons for Firefox Browser. */
+.page-num-input input[type="number"] {
+    appearance: textfield;
 }
 
 .page-num-input-num-pages-text {


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
Fixes #103 .

# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Specify type of input when removing spinner buttons in Webkit-based browsers.
2. Remove spin buttons on number input fields in Firefox.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Repeated the issue reproduction steps and observed the number input field unobstructed in Firefox.
   ![image](https://github.com/user-attachments/assets/95381a8b-f62d-47c1-b9f8-5101d50357b6)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced styling for number input fields by removing default spin buttons in WebKit-based browsers and Firefox.
	- Maintained existing styles for the `.page-num-input` class, ensuring consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->