### PR TITLE
Add warning that decoder format string syntax will change in a future release.

### DIFF
--- a/src/components/modals/SettingsModal/SettingsDialog.tsx
+++ b/src/components/modals/SettingsModal/SettingsDialog.tsx
@@ -33,7 +33,8 @@ import ThemeSwitchToggle from "./ThemeSwitchToggle";
 
 const CONFIG_FORM_FIELDS = [
     {
-        helperText: "[JSON] Log messages conversion formats.",
+        helperText: "[JSON] Log messages conversion pattern. The current syntax is similar to" +
+            " Logback conversion patterns but will change in a future release.",
         initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).formatString,
         label: "Decoder: Format string",
         name: LOCAL_STORAGE_KEY.DECODER_OPTIONS_FORMAT_STRING,


### PR DESCRIPTION
# References

# Description
We are making a change to decoder format string syntax very soon. Adding disclaimer in the settings dialog so that users are aware of the incoming change.

# Validation performed
Open settings dialog and observe that the new helper text under Decoder: Format string.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated helper text in the SettingsDialog to clarify log message conversion formats.

- **Bug Fixes**
	- Enhanced clarity of configuration field descriptions for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->