### PR TITLE
docs: Add file path of sample log to online demo link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ features.
 
 # Online Demo
 
-* A demo of the log viewer can be found [here][online-demo]
+* A demo of the log viewer can be found [here][online-demo].
 * The demo loads a Hadoop YARN log file from the [hive-24hrs] log dataset.
   * More info on the dataset and other datasets can be found [here][datasets].
 * To open an IR stream, drag and drop it onto the log viewer or use the open


### PR DESCRIPTION
# Description
Link now points to sample log file instead of base viewer path. I also made slight change to README for better
clarity. 

# Validation performed
None



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and accessibility of the `README.md` file for the `yscope-log-viewer`.
	- Updated the introductory section to highlight the online demo of the log viewer.
	- Enhanced the "Online Demo" section with a more readable reference link.
	- Added a new reference link for direct access to the online demo at the end of the document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->