### PR TITLE
fix(formatter): Add newline between log events when format string is empty (fixes #136).

### DIFF
--- a/src/services/formatters/YscopeFormatter/index.ts
+++ b/src/services/formatters/YscopeFormatter/index.ts
@@ -40,7 +40,7 @@ class YscopeFormatter implements Formatter {
     formatLogEvent (logEvent: LogEvent): string {
         // Empty format string is special case where formatter returns all fields as JSON.
         if ("" === this.#processedFormatString) {
-            return `${jsonValueToString(logEvent.fields)}\n`
+            return `${jsonValueToString(logEvent.fields)}\n`;
         }
 
         const formattedLogFragments: string[] = [];


### PR DESCRIPTION

# Description
Fixes #136 - all json events were concatenated together when format string is empty.

Missed during testing as test case was too narrow.

# Validation performed
Tested with large jsonl file and logs were seperated by newline. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the log event formatting to include a newline character when the format string is empty, improving readability in log outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->