### PR TITLE
fix(docs): Fix vertical padding issue for "Decoder: Format String" helper text (fixes #142).

### DIFF
--- a/src/components/modals/SettingsModal/SettingsDialog.tsx
+++ b/src/components/modals/SettingsModal/SettingsDialog.tsx
@@ -35,7 +35,7 @@ import ThemeSwitchToggle from "./ThemeSwitchToggle";
 const CONFIG_FORM_FIELDS = [
     {
         helperText: (
-            <p>
+            <span>
                 [JSON] Format string for formatting a JSON log event as plain text. See the
                 {" "}
                 <Link
@@ -48,7 +48,7 @@ const CONFIG_FORM_FIELDS = [
                 </Link>
                 {" "}
                 or leave this blank to display the entire log event.
-            </p>
+            </span>
         ),
         initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).formatString,
         label: "Decoder: Format string",


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
fixes #142
1. Change `<p>` tag to `<span>` in settings helper text.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Repeat the "Reproduction steps" in the issue.
2. Observed the extra padding is removed which is consistent with the helper texts of the other fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced presentation of helper text in the "Decoder: Format string" configuration field within the SettingsDialog.

- **Bug Fixes**
	- No bug fixes were made in this release. 

- **Documentation**
	- No changes to documentation were made in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->