### PR TITLE
fix(sidebar): Fix sidebar tab list overflow on auto-collapse (fixes #124).

### DIFF
--- a/src/components/CentralContainer/Sidebar/SidebarTabs/index.css
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/index.css
@@ -1,5 +1,5 @@
 .sidebar-tabs {
-    overflow-y: hidden;
+    overflow: hidden;
     flex-grow: 1;
     width: calc(100% - var(--ylv-panel-resize-handle-width));
     height: calc(100vh - var(--ylv-menu-bar-height) - var(--ylv-status-bar-height));


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
fixes #124 
1. Change the CSS property `overflow-y` to `overflow` in class `.sidebar-tabs` so that the behaviour is explicitly specified both the x & y directions.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Repeated the "Reproduction steps" in the issue.
2. Observed the scroll indicator did not show up when auto-collapse was triggered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the overflow behavior of the sidebar tabs to enhance the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->