### PR TITLE
fix(editor): Make "Z" suffix optional in date token of the custom Monaco log language definition (fixes #149).

### DIFF
--- a/src/components/Editor/MonacoInstance/language.ts
+++ b/src/components/Editor/MonacoInstance/language.ts
@@ -33,7 +33,7 @@ const setupCustomLogLanguage = () => {
                     TOKEN_NAME.CUSTOM_FATAL,
                 ],
                 [
-                    /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})Z/,
+                    /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})Z?/,
                     TOKEN_NAME.CUSTOM_DATE,
                 ],
                 [


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. fix(editor): Make "Z" suffix optional in Monaco's date parsing definition.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Repeated the reproduction steps in #149 and observed the date getting colored as green as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced date string matching in the Monaco editor to optionally include the 'Z' character.

- **Bug Fixes**
	- Improved flexibility in date format recognition for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->