### PR TITLE
fix(filter): Set max height for the log-level listbox and refine styling (fixes #150).

### DIFF
--- a/src/components/StatusBar/LogLevelSelect/index.css
+++ b/src/components/StatusBar/LogLevelSelect/index.css
@@ -21,8 +21,6 @@
 }
 
 .log-level-select-listbox {
-    /* Disallow width auto-resizing with the `Select` button. */
-    max-width: 0;
     max-height: calc(100vh - var(--ylv-menu-bar-height) - var(--ylv-status-bar-height)) !important;
 }
 

--- a/src/components/StatusBar/LogLevelSelect/index.css
+++ b/src/components/StatusBar/LogLevelSelect/index.css
@@ -23,6 +23,7 @@
 .log-level-select-listbox {
     /* Disallow width auto-resizing with the `Select` button. */
     max-width: 0;
+    max-height: calc(100vh - var(--ylv-menu-bar-height) - var(--ylv-status-bar-height)) !important;
 }
 
 .log-level-select-option-text-tooltip {

--- a/src/components/StatusBar/LogLevelSelect/index.tsx
+++ b/src/components/StatusBar/LogLevelSelect/index.tsx
@@ -259,6 +259,13 @@ const LogLevelSelect = () => {
                 listbox: {
                     className: "log-level-select-listbox",
                     placement: "top-end",
+                    modifiers: [
+                        // Disallow listbox width auto-resizing with the `Select` button.
+                        {name: "equalWidth", enabled: false},
+
+                        // Remove gap between the listbox and the `Select` button.
+                        {name: "offset", enabled: false},
+                    ],
                 },
             }}
         >


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Set max height for log-level listbox.
2. Disable "equalWidth" modifier to prevent width auto-resizing with the `Select` button.
3. Disable "offset" modifier to remove gap between the listbox and the button.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Repeated the reproduction steps in #150 and observe the log-level listbox fully expanded when the viewport is of size 650x330.
2. Further shrank the height of the window to make it 650x300 and observed the listbox expanded but did not cover the menu bar.
   ![image](https://github.com/user-attachments/assets/5557e045-5b3b-4b4a-8343-3be94f78b064)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted styles in the `LogLevelSelect` component to resolve a rounding issue with the listbox positioning.
	- Updated the listbox's maximum height to ensure it fits within the available vertical space.

- **New Features**
	- Enhanced layout of the dropdown menu by disabling automatic width resizing and removing gaps between the listbox and the `Select` button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->