### PR TITLE
fix(filter): Introduce mono font styling for LogLevelChip with Roboto Mono fallback (fixes #154).

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,8 @@
     <link rel="preconnect" crossorigin href="https://fonts.gstatic.com">
     <link rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap">
+    <link rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap">
 </head>
 <body>
 <div id="root"></div>

--- a/src/components/StatusBar/LogLevelSelect/LogLevelChip.css
+++ b/src/components/StatusBar/LogLevelSelect/LogLevelChip.css
@@ -1,6 +1,9 @@
 .log-level-chip {
     /* stylelint-disable-next-line custom-property-pattern */
     --Chip-radius: 0;
+
+    font-family: var(--ylv-ui-mono-font-family), monospace !important;
+    font-weight: 600 !important;
 }
 
 .log-level-chip span {

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,8 @@ html {
     /* font-family globals */
     --ylv-ui-font-family: -apple-system, "BlinkMacSystemFont", system-ui, "Ubuntu", "Droid Sans",
         "Inter";
+    --ylv-ui-mono-font-family: "SF Mono", monaco, menlo, "Ubuntu Mono", "Liberation Mono",
+        "DejaVu Sans Mono", "Roboto Mono";
 
     /* size globals */
     --ylv-status-bar-height: 32px;


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Add `var(--ylv-ui-mono-font-family)` and apply it to LogLevelChip.
2. Add Roboto Mono font and use it as the fallback font for `var(--ylv-ui-mono-font-family)`.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Repeated the reproduction steps on Windows and observed the "W" was no longer truncated.
   ![fe6fe3db4080f6db4c530f17b400dc5](https://github.com/user-attachments/assets/56f1ff65-b8d0-497b-9d7b-367f8a608935)

2. Repeated the same steps on WSL Ubuntu 22.04 Firefox 133.0.3, observed the log level chips displayed correctly as shown below
   ![61890ddff2922e7c48f8653c13ba48e](https://github.com/user-attachments/assets/43c819d2-6457-42e3-95fa-d73c9d4cc45a)

3. Repeated the same steps on macOS 15.0.1 (24A348) Safari 18.0.1 (20619.1.26.31.7), observed the log level chips displayed correctly as shown below
   ![ba4bb2b0d855528001be2dead5d5fcc](https://github.com/user-attachments/assets/ce545206-14dd-4783-b4fc-43268c641510)
