### PR TITLE
ci: Set `persist-credentials` to `false` for all instances of `actions/checkout`.

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
         with:
+          persist-credentials: false
           submodules: "recursive"
 
       - uses: "actions/setup-node@v4"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
         with:
+          persist-credentials: false
           submodules: "recursive"
       - uses: "actions/setup-node@v4"
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
         with:
+          persist-credentials: false
           submodules: "recursive"
       - uses: "actions/setup-node@v4"
         with:


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->
1. Set "persist-credentials" to false for all GH `actions/checkout`. Rationale: https://github.com/actions/checkout/issues/485

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Merged the branch into @junhaoliao 's fork's `main` branch and observed all workflow runs were successful: 
* deploy-github-pages: https://github.com/junhaoliao/yscope-log-viewer/actions/runs/12634700648
* lint: https://github.com/junhaoliao/yscope-log-viewer/actions/runs/12634700642
* test: https://github.com/junhaoliao/yscope-log-viewer/actions/runs/12634700659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows to enhance security by preventing credential persistence during repository checkout.
	- Modified deployment, linting, and testing workflows to limit GitHub credential exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->