### PR TITLE
feat(decoder): Add support for log-level filtering of structured IR streams. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/icons-material": "^6.1.0",
         "@mui/joy": "^5.0.0-beta.48",
         "axios": "^1.7.2",
-        "clp-ffi-js": "^0.3.0",
+        "clp-ffi-js": "^0.3.3",
         "dayjs": "^1.11.11",
         "monaco-editor": "^0.50.0",
         "react": "^18.3.1",
@@ -5841,10 +5841,9 @@
       }
     },
     "node_modules/clp-ffi-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/clp-ffi-js/-/clp-ffi-js-0.3.0.tgz",
-      "integrity": "sha512-+jNULrIosKTSP9WbwDa9AcXzgHCN9W3/iZsQW6jjrzCRvqj9OKXwGzPKT1od6nDsSsKPNVqeBSmasGUWExtadA==",
-      "license": "Apache-2.0"
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/clp-ffi-js/-/clp-ffi-js-0.3.3.tgz",
+      "integrity": "sha512-jfPTga6fDPWykAkv1rd9/zcy/UI3HVyIeXt5w4ShlN/ds9jxSTphFFTS0LI0Nb0DPU1pivhPF54GD1wjxvByUQ=="
     },
     "node_modules/clsx": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mui/icons-material": "^6.1.0",
     "@mui/joy": "^5.0.0-beta.48",
     "axios": "^1.7.2",
-    "clp-ffi-js": "^0.3.0",
+    "clp-ffi-js": "^0.3.3",
     "dayjs": "^1.11.11",
     "monaco-editor": "^0.50.0",
     "react": "^18.3.1",


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
PR #85 added support for structured IR streams (IRV2), but did not support filtering. This PR adds filtering support by updating  clp-ffi-js to the latest version, which now supports filtering for structured IR streams.

# Validation performed
Tested filtering works 
![Screenshot 2025-01-06 at 3 04 10 PM](https://github.com/user-attachments/assets/511edb57-b90c-42e8-b8c0-0f764dcc438a)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Update**
	- Updated `clp-ffi-js` package to version 0.3.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->