### PR TITLE
fix(docs): Correct minutes format specifier in example format string (fixes #164).

### DIFF
--- a/docs/src/user-guide/format-struct-logs-syntax.md
+++ b/docs/src/user-guide/format-struct-logs-syntax.md
@@ -80,7 +80,7 @@ Consider the following log event:
 We can format this using the following YScope format string:
 
 ```
-{@timestamp:timestamp:YYYY-MM-DD HH\:MM\:ss.SSS} {level} \{{thread}\} latency={latency.secs:round} {an\.odd\.key\{name\}}
+{@timestamp:timestamp:YYYY-MM-DD HH\:mm\:ss.SSS} {level} \{{thread}\} latency={latency.secs:round} {an\.odd\.key\{name\}}
 ```
 
 * In the first placeholder, we have the field name `@timestamp`, a formatter called `timestamp`, and


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

As #164 describes, in the docs, the example format string uses the wrong format specifier for minutes (the issue says months, but means minutes). This PR fixes the doc.

# Validation performed
<!-- What tests and validation you performed on the change -->

Validated that opening the following file in the log viewer, and formatting it with the format string in the example showed the minutes of the second log as `59` (✅) rather than `12` (❌).

```json
{"@timestamp":1735689600000,"level":"INFO","an.odd.key{name}":"Happy New Year!"}
{"@timestamp":1735689599999,"level":"INFO","an.odd.key{name}":"We need to go back to the future!"}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated structured log format string documentation
	- Corrected timestamp minute representation from uppercase `MM` to lowercase `mm`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->