### PR TITLE
fix(logEventNum): keyboard navigation shortcuts should update the log event number

### DIFF
--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -83,15 +83,24 @@ const Editor = () => {
             case ACTION_NAME.LAST_PAGE:
                 loadPageByAction({code: actionName, args: null});
                 break;
-            case ACTION_NAME.PAGE_TOP:
+            case ACTION_NAME.PAGE_TOP: {
                 goToPositionAndCenter(editor, {lineNumber: 1, column: 1});
+                const newlogEventNum = beginLineNumToLogEventNumRef.current.get(1);
+                if (newlogEventNum) {
+                    updateWindowUrlHashParams({logEventNum: newlogEventNum});
+                }
                 break;
+            }
             case ACTION_NAME.PAGE_BOTTOM: {
                 const lineCount = editor.getModel()?.getLineCount();
                 if ("undefined" === typeof lineCount) {
                     break;
                 }
                 goToPositionAndCenter(editor, {lineNumber: lineCount, column: 1});
+                const newlogEvent = beginLineNumToLogEventNumRef.current.get(1);
+                if (newlogEvent) {
+                    updateWindowUrlHashParams({logEventNum: newlogEvent + pageSizeRef.current - 1});
+                }
                 break;
             }
             default:


### PR DESCRIPTION
I quote here the description of #105:

> The CTRL + U/I keyboard shortcuts navigate to the top and bottom of the current page, but they don't update the log event number.
