### PR TITLE
fix(query): Restart query on log filter change (fixes #168).

### DIFF
--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
@@ -30,7 +30,6 @@ import {
     TAB_NAME,
 } from "../../../../../typings/tab";
 import {isDisabled} from "../../../../../utils/states";
-import {defer} from "../../../../../utils/time";
 import CustomTabPanel from "../CustomTabPanel";
 import PanelTitleButton from "../PanelTitleButton";
 import ResultsGroup from "./ResultsGroup";
@@ -87,8 +86,11 @@ const SearchTabPanel = () => {
     const isQueryInputBoxDisabled = isDisabled(uiState, UI_ELEMENT.QUERY_INPUT_BOX);
 
     useEffect(() => {
+        // NOTE: When `uiState` transitions to `UI_STATE.FILTER_CHANGING`, the request to update
+        // the filter in the MainWorker should have already been sent. At this point, any new
+        // requests added to the MainWorker's message queue will use the updated filter.
         if (uiState === UI_STATE.FILTER_CHANGING) {
-            defer(handleQuerySubmit);
+            handleQuerySubmit();
         }
     }, [
         handleQuerySubmit,

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
@@ -1,5 +1,7 @@
 import React, {
+    useCallback,
     useContext,
+    useEffect,
     useState,
 } from "react";
 
@@ -19,12 +21,16 @@ import {
     QUERY_PROGRESS_VALUE_MAX,
     QueryArgs,
 } from "../../../../../typings/query";
-import {UI_ELEMENT} from "../../../../../typings/states";
+import {
+    UI_ELEMENT,
+    UI_STATE,
+} from "../../../../../typings/states";
 import {
     TAB_DISPLAY_NAMES,
     TAB_NAME,
 } from "../../../../../typings/tab";
 import {isDisabled} from "../../../../../utils/states";
+import {defer} from "../../../../../utils/time";
 import CustomTabPanel from "../CustomTabPanel";
 import PanelTitleButton from "../PanelTitleButton";
 import ResultsGroup from "./ResultsGroup";
@@ -49,14 +55,19 @@ const SearchTabPanel = () => {
         setIsAllExpanded((v) => !v);
     };
 
-    const handleQuerySubmit = (newArgs: Partial<QueryArgs>) => {
+    const handleQuerySubmit = useCallback((newArgs?: Partial<QueryArgs>) => {
         startQuery({
             isCaseSensitive: isCaseSensitive,
             isRegex: isRegex,
             queryString: queryString,
             ...newArgs,
         });
-    };
+    }, [
+        isCaseSensitive,
+        isRegex,
+        queryString,
+        startQuery,
+    ]);
 
     const handleQueryInputChange = (ev: React.ChangeEvent<HTMLTextAreaElement>) => {
         setQueryString(ev.target.value);
@@ -74,6 +85,15 @@ const SearchTabPanel = () => {
     };
 
     const isQueryInputBoxDisabled = isDisabled(uiState, UI_ELEMENT.QUERY_INPUT_BOX);
+
+    useEffect(() => {
+        if (uiState === UI_STATE.FILTER_CHANGING) {
+            defer(handleQuerySubmit);
+        }
+    }, [
+        handleQuerySubmit,
+        uiState,
+    ]);
 
     return (
         <CustomTabPanel

--- a/src/contexts/StateContextProvider.tsx
+++ b/src/contexts/StateContextProvider.tsx
@@ -465,7 +465,7 @@ const StateContextProvider = ({children}: StateContextProviderProps) => {
         if (null === mainWorkerRef.current) {
             return;
         }
-        setUiState(UI_STATE.FAST_LOADING);
+        setUiState(UI_STATE.FILTER_CHANGING);
         workerPostReq(mainWorkerRef.current, WORKER_REQ_CODE.SET_FILTER, {
             cursor: {code: CURSOR_CODE.EVENT_NUM, args: {eventNum: logEventNumRef.current ?? 1}},
             logLevelFilter: filter,

--- a/src/typings/states.ts
+++ b/src/typings/states.ts
@@ -14,6 +14,11 @@ enum UI_STATE {
     FILE_LOADING,
 
     /**
+     * When a log filter (e.g., the log-level filter) change request is pending response.
+     */
+    FILTER_CHANGING,
+
+    /**
      * When a fast request is pending response. In this state, UI elements are not visually
      * disabled but instead ignore pointer events. Rapidly disabling/enabling UI elements is
      * jarring to the user.
@@ -76,6 +81,16 @@ const UI_STATE_GRID: UiStateGrid = Object.freeze({
         [UI_ELEMENT.LOG_LEVEL_FILTER]: false,
         [UI_ELEMENT.NAVIGATION_BAR]: false,
         [UI_ELEMENT.OPEN_FILE_BUTTON]: false,
+        [UI_ELEMENT.PROGRESS_BAR]: true,
+        [UI_ELEMENT.QUERY_INPUT_BOX]: false,
+    },
+    [UI_STATE.FILTER_CHANGING]: {
+        [UI_ELEMENT.DRAG_AND_DROP]: true,
+        [UI_ELEMENT.EXPORT_LOGS_BUTTON]: true,
+        [UI_ELEMENT.LOG_EVENT_NUM_DISPLAY]: true,
+        [UI_ELEMENT.LOG_LEVEL_FILTER]: false,
+        [UI_ELEMENT.NAVIGATION_BAR]: true,
+        [UI_ELEMENT.OPEN_FILE_BUTTON]: true,
         [UI_ELEMENT.PROGRESS_BAR]: true,
         [UI_ELEMENT.QUERY_INPUT_BOX]: false,
     },


### PR DESCRIPTION
# Description
Fixes the bug reported in #168.
based on discussions with @Henry8192 :
1. Add a new `UI_STATE` named `FILTER_CHANGING` for filter changing and set the uiState as so when the log-level filter is being changed.
2. Schedule query restart when the state becomes `FILTER_CHANGING`

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Launched the debug server with the demo file: https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst
2. Started query with keyword "info" and observed the "INFO" level query results shown in the search panel.
3. Changed log-level filter to "ERROR" and observed no "INFO" level query results shown in the search panel.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the user interface feedback during log filtering. UI controls now update dynamically to reflect when filters are being adjusted, providing a clearer indication of progress.
  
- **Refactor**
  - Optimised the query submission process to automatically respond to filter adjustments, ensuring smoother and more responsive interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->