### PR TITLE
fix: Highlight log level "WARNING" (fixes #193)

### DIFF
--- a/src/components/Editor/MonacoInstance/language.ts
+++ b/src/components/Editor/MonacoInstance/language.ts
@@ -21,7 +21,7 @@ const setupCustomLogLanguage = () => {
                     TOKEN_NAME.CUSTOM_INFO,
                 ],
                 [
-                    "WARN",
+                    /\b(WARN|WARNING)\b/,
                     TOKEN_NAME.CUSTOM_WARN,
                 ],
                 [


### PR DESCRIPTION
# Description
Fixes #193.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
Open a log file that contains log level names as "WARNING", the log level is highlighted entirely to red.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
