### PR TITLE
fix: Prepend formatted timestamps to unstructured log events (fixes #201).

### DIFF
--- a/src/components/Editor/MonacoInstance/language.ts
+++ b/src/components/Editor/MonacoInstance/language.ts
@@ -33,7 +33,7 @@ const setupCustomLogLanguage = () => {
                     TOKEN_NAME.CUSTOM_FATAL,
                 ],
                 [
-                    /\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}:\d{2}(?:[\.,]\d+)?(?:[+-]\d{2}:?\d{2}|Z)?)?/
+                    /\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:[+-]\d{2}:?\d{2}|Z)?)?/,
                     TOKEN_NAME.CUSTOM_DATE,
                 ],
                 [

--- a/src/components/Editor/MonacoInstance/language.ts
+++ b/src/components/Editor/MonacoInstance/language.ts
@@ -33,7 +33,7 @@ const setupCustomLogLanguage = () => {
                     TOKEN_NAME.CUSTOM_FATAL,
                 ],
                 [
-                    /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})Z?/,
+                    /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}/,
                     TOKEN_NAME.CUSTOM_DATE,
                 ],
                 [

--- a/src/components/Editor/MonacoInstance/language.ts
+++ b/src/components/Editor/MonacoInstance/language.ts
@@ -33,7 +33,7 @@ const setupCustomLogLanguage = () => {
                     TOKEN_NAME.CUSTOM_FATAL,
                 ],
                 [
-                    /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}/,
+                    /\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}:\d{2}(?:[\.,]\d+)?(?:[+-]\d{2}:?\d{2}|Z)?)?/
                     TOKEN_NAME.CUSTOM_DATE,
                 ],
                 [

--- a/src/services/decoders/ClpIrDecoder/index.ts
+++ b/src/services/decoders/ClpIrDecoder/index.ts
@@ -82,11 +82,11 @@ class ClpIrDecoder implements Decoder {
     /**
      * Formats unstructured log events by prepending a formatted timestamp to each message.
      *
-     * @param results
+     * @param logEvents
      * @return The formatted log events.
      */
-    static #formatUnstructuredResults = (results: DecodeResult[]): DecodeResult[] => {
-        for (const r of results) {
+    static #formatUnstructuredResults = (logEvents: DecodeResult[]): DecodeResult[] => {
+        for (const r of logEvents) {
             const [
                 message, timestamp,
             ] = r;
@@ -95,7 +95,7 @@ class ClpIrDecoder implements Decoder {
             r[0] = dayJsTimestamp.format("YYYY-MM-DDTHH:mm:ss.SSSZ") + message;
         }
 
-        return results;
+        return logEvents;
     };
 
     getEstimatedNumEvents (): number {

--- a/src/services/decoders/ClpIrDecoder/index.ts
+++ b/src/services/decoders/ClpIrDecoder/index.ts
@@ -80,7 +80,7 @@ class ClpIrDecoder implements Decoder {
     }
 
     /**
-     * Formats unstructured log events by prepending formatted timestamp to each message.
+     * Formats unstructured log events by prepending a formatted timestamp to each message.
      *
      * @param results
      * @return The formatted log events.

--- a/src/services/decoders/ClpIrDecoder/index.ts
+++ b/src/services/decoders/ClpIrDecoder/index.ts
@@ -128,6 +128,15 @@ class ClpIrDecoder implements Decoder {
         return true;
     }
 
+    /**
+     * See {@link Decoder.decodeRange}.
+     *
+     * @param beginIdx
+     * @param endIdx
+     * @param useFilter
+     * @return
+     * @throws {Error} if the formatter is not set for structured logs.
+     */
     decodeRange (
         beginIdx: number,
         endIdx: number,
@@ -146,7 +155,7 @@ class ClpIrDecoder implements Decoder {
             if (this.#streamType === CLP_IR_STREAM_TYPE.STRUCTURED) {
                 // eslint-disable-next-line no-warning-comments
                 // TODO: Revisit when we allow displaying structured logs without a formatter.
-                console.error("Formatter is not set for structured logs.");
+                throw new Error("Formatter is not set for structured logs.");
             }
 
             return ClpIrDecoder.#formatUnstructuredResults(results);

--- a/src/services/decoders/ClpIrDecoder/index.ts
+++ b/src/services/decoders/ClpIrDecoder/index.ts
@@ -80,7 +80,7 @@ class ClpIrDecoder implements Decoder {
     }
 
     /**
-     * Formats unstructured log events by prepending the timestamp to each message.
+     * Formats unstructured log events by prepending formatted timestamp to each message.
      *
      * @param results
      * @return The formatted log events.

--- a/src/services/decoders/ClpIrDecoder/index.ts
+++ b/src/services/decoders/ClpIrDecoder/index.ts
@@ -79,6 +79,25 @@ class ClpIrDecoder implements Decoder {
         return new ClpIrDecoder(module, dataArray, decoderOptions);
     }
 
+    /**
+     * Formats unstructured log events by prepending the timestamp to each message.
+     *
+     * @param results
+     * @return The formatted log events.
+     */
+    static #formatUnstructuredResults = (results: DecodeResult[]): DecodeResult[] => {
+        for (const r of results) {
+            const [
+                message, timestamp,
+            ] = r;
+
+            const dayJsTimestamp: Dayjs = convertToDayjsTimestamp(timestamp);
+            r[0] = dayJsTimestamp.format("YYYY-MM-DDTHH:mm:ss.SSSZ") + message;
+        }
+
+        return results;
+    };
+
     getEstimatedNumEvents (): number {
         return this.#streamReader.getNumEventsBuffered();
     }
@@ -130,7 +149,7 @@ class ClpIrDecoder implements Decoder {
                 console.error("Formatter is not set for structured logs.");
             }
 
-            return results;
+            return ClpIrDecoder.#formatUnstructuredResults(results);
         }
 
         for (const r of results) {


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. fix: Format unstructured log events by prepending timestamps.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. Launched debug server and opened demo file https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst in the log viewer.
2. Observed formatted timestamps are prepended to each log event. Compared the text with an older version (1e8455ef11812077760a6db71aab0d07c6e8233c) of the log viewer, which is before the unintended formatted timestamp removal in #192 , and found the `year`, `zero-padded month`, `zero-padded day`, `T`, `zero-padded 24-h hour`, `zero-padded minute`, `zero-padded second` and `zero-padded 3-digit milliseconds` parts matched. For the timezone, `+00:00` is shown to represent UTC, instead of `Z` or `` (not present) depending on the timestamp format string in the IR file's metadata.
3. Observed the dates (i.e., formatted timestamps) are fully highlighted in green colour in the monaco-editor. 


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced date recognition in log messages to support timestamps with optional time components, fractional seconds, and timezone offsets.
  - Introduced consistent formatting for unstructured log entries by adding a formatted timestamp to each message.
- **Bug Fixes**
  - Improved error handling in the decoding process by replacing console error logging with exception throwing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->