### PR TITLE
feat(editor): Add keyboard shortcut to toggle word wrapping (resolves #60).

### DIFF
--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -156,6 +156,15 @@ const Editor = () => {
             case ACTION_NAME.COPY_LOG_EVENT:
                 handleCopyLogEventAction(editor, beginLineNumToLogEventNumRef.current);
                 break;
+            case ACTION_NAME.WORD_WRAP: {
+                const currentWordWrap = editor.getRawOptions().wordWrap;
+                const newWordWrap = "on" === currentWordWrap ?
+                    "off" :
+                    "on";
+
+                editor.updateOptions({wordWrap: newWordWrap});
+                break;
+            }
             default:
                 break;
         }

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -113,6 +113,7 @@ const handleCopyLogEventAction = (
 };
 
 /**
+ * Toggles the word wrap setting in the editor between "on" and "off".
  *
  * @param editor
  */

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -113,6 +113,19 @@ const handleCopyLogEventAction = (
 };
 
 /**
+ *
+ * @param editor
+ */
+const handleWordWrapAction = (editor: monaco.editor.IStandaloneCodeEditor) => {
+    const currentWordWrap = editor.getRawOptions().wordWrap;
+    const newWordWrap = "on" === currentWordWrap ?
+        "off" :
+        "on";
+
+    editor.updateOptions({wordWrap: newWordWrap});
+};
+
+/**
  * Renders a read-only editor for viewing logs.
  *
  * @return
@@ -156,15 +169,9 @@ const Editor = () => {
             case ACTION_NAME.COPY_LOG_EVENT:
                 handleCopyLogEventAction(editor, beginLineNumToLogEventNumRef.current);
                 break;
-            case ACTION_NAME.WORD_WRAP: {
-                const currentWordWrap = editor.getRawOptions().wordWrap;
-                const newWordWrap = "on" === currentWordWrap ?
-                    "off" :
-                    "on";
-
-                editor.updateOptions({wordWrap: newWordWrap});
+            case ACTION_NAME.WORD_WRAP:
+                handleWordWrapAction(editor);
                 break;
-            }
             default:
                 break;
         }

--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -74,7 +74,7 @@ const EDITOR_ACTIONS : EditorAction[] = [
     {
         actionName: ACTION_NAME.WORD_WRAP,
         keyBindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
-        label: "Toggle Word Wrap",
+        label: "Toggle word wrap",
     },
 ];
 

--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -13,6 +13,7 @@ enum ACTION_NAME {
     PAGE_BOTTOM = "pageBottom",
     RELOAD = "reload",
     COPY_LOG_EVENT = "copyLogEvent",
+    WORD_WRAP = "wordWrap",
 }
 
 interface EditorAction {
@@ -69,6 +70,11 @@ const EDITOR_ACTIONS : EditorAction[] = [
         contextMenuOrder: 2,
         keyBindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyC],
         label: "Copy Log Event",
+    },
+    {
+        actionName: ACTION_NAME.WORD_WRAP,
+        keyBindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
+        label: "Toggle Word Wrap",
     },
 ];
 


### PR DESCRIPTION
# Description
Fixes #60.
Add a keyboard shortcut `Alt+Z` for users to toggle word wrap.


# Checklist
* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
Open log viewer with `http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst#logEventNum=1`, press `Alt+Z` and notice the change in line 7.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled a toggle for word wrapping in the editor, allowing you to switch the wrap mode on and off.
	- Added a keyboard shortcut (Alt+Z) for quick access to the word wrap toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->