### PR TITLE
fix: Change the type of timestamp property of the return value of #decodeLogEvent to bigint (fixes #226). 

### DIFF
--- a/src/services/decoders/JsonlDecoder/index.ts
+++ b/src/services/decoders/JsonlDecoder/index.ts
@@ -247,7 +247,7 @@ class JsonlDecoder implements Decoder {
 
         return [
             message,
-            timestamp,
+            BigInt(timestamp),
             logLevel,
             logEventIdx + 1,
         ];


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR is to fix #226 

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Passed the lint.
Did the basic manual UI testing and it looks good.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
