### PR TITLE
feat(settings): Refactor settings form into sections (resolves #215)

### DIFF
--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/SettingsFormField.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/SettingsFormField.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+import {
+    FormControl,
+    FormHelperText,
+    FormLabel,
+    Input,
+} from "@mui/joy";
+
+
+interface SettingsFormFieldProps {
+    configKey: string;
+    helperText: string | React.ReactNode;
+    initialValue: string | number;
+    label: string;
+    type: string;
+}
+
+/**
+ * Displays a form field for user input of configuration values.
+ *
+ * @param props
+ * @param props.configKey
+ * @param props.helperText
+ * @param props.initialValue
+ * @param props.label
+ * @param props.type
+ * @return
+ */
+const SettingsFormField = ({
+    configKey,
+    helperText,
+    initialValue,
+    label,
+    type,
+}: SettingsFormFieldProps) => (
+    <FormControl>
+        <FormLabel>
+            {label}
+        </FormLabel>
+        <Input
+            defaultValue={initialValue}
+            name={configKey}
+            type={type}/>
+        <FormHelperText>
+            {helperText}
+        </FormHelperText>
+    </FormControl>
+);
+
+
+export type {SettingsFormFieldProps};
+export default SettingsFormField;

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/SettingsFormFieldSectionsGroup.css
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/SettingsFormFieldSectionsGroup.css
@@ -1,0 +1,11 @@
+.settings-form-field-sections-group-container {
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: 0.75rem;
+}
+
+.settings-form-field-sections-group {
+    gap: 0.5rem;
+}

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/SettingsFormFieldSectionsGroup.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/SettingsFormFieldSectionsGroup.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+
+import {
+    AccordionGroup,
+    Box,
+    Link,
+} from "@mui/joy";
+
+import {
+    CONFIG_KEY,
+    LOCAL_STORAGE_KEY,
+} from "../../../../../typings/config";
+import {getConfig} from "../../../../../utils/config";
+import {SettingsFormFieldProps} from "./SettingsFormField";
+import SettingsFormFieldsSection from "./SettingsFormFieldsSection";
+import ThemeSwitchFormField from "./ThemeSwitchFormField";
+
+import "./SettingsFormFieldSectionsGroup.css";
+
+
+/**
+ * Gets form fields information for user input of configuration values.
+ *
+ * @return A list of form fields information.
+ */
+const getConfigFormFieldSections = (): Array<{
+    name: string;
+    fields: Array<React.ReactNode | SettingsFormFieldProps>;
+}> => [
+    {
+        name: "Common",
+        fields: [
+            <ThemeSwitchFormField key={null}/>,
+            {
+                configKey: LOCAL_STORAGE_KEY.PAGE_SIZE,
+                helperText: "Number of log messages to display per page.",
+                initialValue: getConfig(CONFIG_KEY.PAGE_SIZE),
+                label: "View: Page size",
+                type: "number",
+            },
+        ],
+    },
+    {
+        name: "KV-Pairs IR / JSON",
+        fields: [
+            {
+                configKey: LOCAL_STORAGE_KEY.DECODER_OPTIONS_FORMAT_STRING,
+                helperText: (
+                    <span>
+                        Format string for formatting a JSON log event as plain text. See the
+                        {" "}
+                        <Link
+                            href={"https://docs.yscope.com/yscope-log-viewer/main/user-guide/format-struct-logs-overview.html"}
+                            level={"body-sm"}
+                            rel={"noopener"}
+                            target={"_blank"}
+                        >
+                            format string syntax docs
+                        </Link>
+                        {" "}
+                        or leave this blank to display the entire log event.
+                    </span>
+                ),
+                initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).formatString,
+                label: "Decoder: Format string",
+                type: "text",
+            },
+            {
+                configKey: LOCAL_STORAGE_KEY.DECODER_OPTIONS_LOG_LEVEL_KEY,
+                helperText: "Key to extract the log level from.",
+                initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).logLevelKey,
+                label: "Decoder: Log level key",
+                type: "text",
+            },
+            {
+                configKey: LOCAL_STORAGE_KEY.DECODER_OPTIONS_TIMESTAMP_KEY,
+                helperText: "Key to extract the log timestamp from.",
+                initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).timestampKey,
+                label: "Decoder: Timestamp key",
+                type: "text",
+            },
+        ],
+    },
+];
+
+/**
+ * Displays a group of form fields for user input of configuration values.
+ *
+ * @return
+ */
+const SettingsFormFieldSectionsGroup = () => (
+    <Box className={"settings-form-field-sections-group-container"}>
+        <AccordionGroup
+            className={"settings-form-field-sections-group"}
+            size={"sm"}
+        >
+            {getConfigFormFieldSections().map(
+                ({name, fields}, i) => (
+                    <SettingsFormFieldsSection
+                        fields={fields}
+                        key={i}
+                        name={name}/>
+                )
+            )}
+        </AccordionGroup>
+    </Box>
+);
+
+
+export default SettingsFormFieldSectionsGroup;

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/SettingsFormFieldsSection.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/SettingsFormFieldsSection.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    Typography,
+} from "@mui/joy";
+
+import SettingsFormField, {SettingsFormFieldProps} from "./SettingsFormField";
+
+
+interface SettingsFormFieldsSectionProps {
+    name: string;
+    fields: Array<React.ReactNode | SettingsFormFieldProps>;
+}
+
+/**
+ * Displays a section of form fields for user input of configuration values.
+ *
+ * @param props
+ * @param props.fields
+ * @param props.name
+ * @return
+ */
+const SettingsFormFieldsSection = ({
+    fields,
+    name,
+}: SettingsFormFieldsSectionProps) => (
+    <Accordion defaultExpanded={true}>
+        <AccordionSummary variant={"soft"}>
+            <Typography level={"title-md"}>
+                {name}
+            </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+            {fields.map(
+                (f, index) => (
+                    React.isValidElement(f) ?
+                        f :
+                        <SettingsFormField
+                            key={index}
+                            {...(f as SettingsFormFieldProps)}/>
+                )
+            )}
+        </AccordionDetails>
+    </Accordion>
+);
+
+
+export default SettingsFormFieldsSection;

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/index.css
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/index.css
@@ -6,11 +6,3 @@
 
     height: 100%;
 }
-
-.settings-form-fields-container {
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    gap: 0.75rem;
-}

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/index.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SettingsTabPanel/index.tsx
@@ -4,14 +4,8 @@ import React, {
 } from "react";
 
 import {
-    Box,
     Button,
     Divider,
-    FormControl,
-    FormHelperText,
-    FormLabel,
-    Input,
-    Link,
 } from "@mui/joy";
 
 import {NotificationContext} from "../../../../../contexts/NotificationContextProvider";
@@ -28,66 +22,12 @@ import {
     TAB_NAME,
 } from "../../../../../typings/tab";
 import {ACTION_NAME} from "../../../../../utils/actions";
-import {
-    getConfig,
-    setConfig,
-} from "../../../../../utils/config";
+import {setConfig} from "../../../../../utils/config";
 import CustomTabPanel from "../CustomTabPanel";
-import ThemeSwitchFormField from "./ThemeSwitchFormField";
+import SettingsFormFieldSectionsGroup from "./SettingsFormFieldSectionsGroup";
 
 import "./index.css";
 
-
-/**
- * Gets form fields information for user input of configuration values.
- *
- * @return A list of form fields information.
- */
-const getConfigFormFields = () => [
-    {
-        helperText: (
-            <span>
-                [JSON] Format string for formatting a JSON log event as plain text. See the
-                {" "}
-                <Link
-                    href={"https://docs.yscope.com/yscope-log-viewer/main/user-guide/format-struct-logs-overview.html"}
-                    level={"body-sm"}
-                    rel={"noopener"}
-                    target={"_blank"}
-                >
-                    format string syntax docs
-                </Link>
-                {" "}
-                or leave this blank to display the entire log event.
-            </span>
-        ),
-        initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).formatString,
-        key: LOCAL_STORAGE_KEY.DECODER_OPTIONS_FORMAT_STRING,
-        label: "Decoder: Format string",
-        type: "text",
-    },
-    {
-        helperText: "[JSON] Key to extract the log level from.",
-        initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).logLevelKey,
-        key: LOCAL_STORAGE_KEY.DECODER_OPTIONS_LOG_LEVEL_KEY,
-        label: "Decoder: Log level key",
-        type: "text",
-    },
-    {
-        helperText: "[JSON] Key to extract the log timestamp from.",
-        initialValue: getConfig(CONFIG_KEY.DECODER_OPTIONS).timestampKey,
-        key: LOCAL_STORAGE_KEY.DECODER_OPTIONS_TIMESTAMP_KEY,
-        label: "Decoder: Timestamp key",
-        type: "text",
-    },
-    {
-        helperText: "Number of log messages to display per page.",
-        initialValue: getConfig(CONFIG_KEY.PAGE_SIZE),
-        key: LOCAL_STORAGE_KEY.PAGE_SIZE,
-        label: "View: Page size",
-        type: "number",
-    },
-];
 
 /**
  * Handles the reset event for the configuration form.
@@ -155,23 +95,7 @@ const SettingsTabPanel = () => {
                 onReset={handleConfigFormReset}
                 onSubmit={handleConfigFormSubmit}
             >
-                <Box className={"settings-form-fields-container"}>
-                    <ThemeSwitchFormField/>
-                    {getConfigFormFields().map((field, index) => (
-                        <FormControl key={index}>
-                            <FormLabel>
-                                {field.label}
-                            </FormLabel>
-                            <Input
-                                defaultValue={field.initialValue}
-                                name={field.key}
-                                type={field.type}/>
-                            <FormHelperText>
-                                {field.helperText}
-                            </FormHelperText>
-                        </FormControl>
-                    ))}
-                </Box>
+                <SettingsFormFieldSectionsGroup/>
                 <Divider/>
                 <Button
                     color={"primary"}


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. Refactor settings form into foldable sections.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Launched the debug server and loaded the app in a browser.
2. Clicked the "Settings" tab and observed that the fields are categorized into two sections: "Common" and "CLP KV-Pairs IR / JSON".
   1. The sections were expanded by default. Clicking on any section title folded the section into title only.
3. Modified each option and clicked "Apply" and observed the log file reloaded with the settings applied.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
