### PR TITLE
fix(css): Correct height property for menu bar elements to use the appropriate variable.

### DIFF
--- a/src/components/MenuBar/index.css
+++ b/src/components/MenuBar/index.css
@@ -5,7 +5,7 @@
     flex-direction: row;
     align-items: center;
 
-    height: var(--ylv-status-bar-height);
+    height: var(--ylv-menu-bar-height);
 
     /* stylelint-disable-next-line custom-property-pattern */
     box-shadow: 0 1px 0 0 var(--joy-palette-neutral-outlinedBorder);
@@ -15,7 +15,7 @@
     display: flex;
     justify-content: center;
     min-width: 48px;
-    height: var(--ylv-status-bar-height);
+    height: var(--ylv-menu-bar-height);
 }
 
 .menu-bar-open-file-icon {


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR fixes a CSS issue where the `height` property for menu bar elements was incorrectly using the `--ylv-status-bar-height` variable. It updates the styles to use the correct `--ylv-menu-bar-height` variable instead, ensuring consistency with design specifications for the menu bar.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. Manually inspected the menu bar in the application UI to verify that it still correctly reflects the intended height.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
