### PR TITLE
fix(config): Remove auto-generated key prefix from default timestamp key (fixes #248).

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -27,7 +27,7 @@ const CONFIG_DEFAULT: ConfigMap = Object.freeze({
     [CONFIG_KEY.DECODER_OPTIONS]: {
         formatString: "",
         logLevelKey: "log.level",
-        timestampKey: "@timestamp",
+        timestampKey: "timestamp",
     },
     [CONFIG_KEY.INITIAL_TAB_NAME]: TAB_NAME.FILE_INFO,
     [CONFIG_KEY.THEME]: THEME_NAME.SYSTEM,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Removes @ symbol from timestamp key allowing json files to open without error.

Fixes #248


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Opens without error


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated default configuration to use "timestamp" instead of "@timestamp" for the timestamp key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->