### PR TITLE
fix(query): Ensure progress is reset and results are cleared if the query string is empty (fixes #266).

### DIFF
--- a/src/stores/queryStore/createQueryControllerSlice.ts
+++ b/src/stores/queryStore/createQueryControllerSlice.ts
@@ -44,15 +44,17 @@ const createQueryControllerSlice: StateCreator<
             queryString,
             queryIsCaseSensitive,
             queryIsRegex,
+            setQueryProgress,
         } = get();
         const {logFileManagerProxy} = useLogFileManagerStore.getState();
         const {postPopUp} = useContextStore.getState();
 
+        setQueryProgress(QUERY_CONTROLLER_DEFAULT.queryProgress);
+        clearQueryResults();
+
         if (QUERY_CONFIG_DEFAULT.queryString === queryString) {
             return;
         }
-
-        clearQueryResults();
 
         (async () => {
             await logFileManagerProxy.startQuery(queryString, queryIsRegex, queryIsCaseSensitive);


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Ensure progress is reset and query results are cleared and if the query string is empty.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. Launched debug server and loaded the log viewer with the demo file in the README.
2. Switched to the Query tab in the left panel. Entered query "123" and observed results shown.
3. Emptied the query input box and observed the results cleared together with the progress bar.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of query progress and results reset when starting a new query, ensuring progress is reset and previous results are cleared immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210245536411625