### PR TITLE
fix(query): Remove incorrect early return on empty query to allow service worker to cancel previous query (fixes #278).

### DIFF
--- a/src/stores/queryStore/createQueryControllerSlice.ts
+++ b/src/stores/queryStore/createQueryControllerSlice.ts
@@ -44,17 +44,11 @@ const createQueryControllerSlice: StateCreator<
             queryString,
             queryIsCaseSensitive,
             queryIsRegex,
-            setQueryProgress,
         } = get();
         const {logFileManagerProxy} = useLogFileManagerStore.getState();
         const {postPopUp} = useContextStore.getState();
 
-        setQueryProgress(QUERY_CONTROLLER_DEFAULT.queryProgress);
         clearQueryResults();
-
-        if (QUERY_CONFIG_DEFAULT.queryString === queryString) {
-            return;
-        }
 
         (async () => {
             await logFileManagerProxy.startQuery(queryString, queryIsRegex, queryIsCaseSensitive);


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. In `startQuery()`, remove an incorrect early return on empty query which was added in #224.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. Loaded demo file: https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst
2. Started a query with an inexistent keyword "12345".
3. Selected all in the query input box and hit "delete" key to clear the query input box. Observed the query progress and results got cleared immediately and the progress bar no longer incremented.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for starting queries, removing unnecessary checks and progress resets for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->