### PR TITLE
refactor: Rename uiStoreState type to UiStoreState to follow PascalCase naming convention (fixes #291).

### DIFF
--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -16,14 +16,14 @@ interface UiStoreActions {
     setUiState: (newUIState: UI_STATE) => void;
 }
 
-type uiStoreState = UiStoreValues & UiStoreActions;
+type UiStoreState = UiStoreValues & UiStoreActions;
 
 const UI_STORE_DEFAULT: UiStoreValues = {
     activeTabName: getConfig(CONFIG_KEY.INITIAL_TAB_NAME),
     uiState: UI_STATE.UNOPENED,
 };
 
-const useUiStore = create<uiStoreState>((set) => ({
+const useUiStore = create<UiStoreState>((set) => ({
     ...UI_STORE_DEFAULT,
     setActiveTabName: (tabName) => {
         set({activeTabName: tabName});


### PR DESCRIPTION
# Description
Fix #291.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated type naming conventions for improved consistency. No impact on user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->