### PR TITLE
feat: search term highlighting within log entry (fixes #189)

### DIFF
--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/QueryInputBox.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/QueryInputBox.tsx
@@ -16,12 +16,18 @@ import ToggleIconButton from "./ToggleIconButton";
 import "./QueryInputBox.css";
 
 
+interface QueryInputBoxProps {
+    onQueryChange: () => void;
+}
+
 /**
  * Provides a text input and optional toggles for submitting search queries.
  *
+ * @param root0
+ * @param root0.onQueryChange
  * @return
  */
-const QueryInputBox = () => {
+const QueryInputBox: React.FC<QueryInputBoxProps> = ({onQueryChange}) => {
     const isCaseSensitive = useQueryStore((state) => state.queryIsCaseSensitive);
     const isRegex = useQueryStore((state) => state.queryIsRegex);
     const querystring = useQueryStore((state) => state.queryString);
@@ -35,16 +41,19 @@ const QueryInputBox = () => {
     const handleQueryInputChange = (ev: React.ChangeEvent<HTMLTextAreaElement>) => {
         setQueryString(ev.target.value);
         startQuery();
+        onQueryChange();
     };
 
     const handleCaseSensitivityButtonClick = () => {
         setQueryIsCaseSensitive(!isCaseSensitive);
         startQuery();
+        onQueryChange();
     };
 
     const handleRegexButtonClick = () => {
         setQueryIsRegex(!isRegex);
         startQuery();
+        onQueryChange();
     };
 
     const isQueryInputBoxDisabled = isDisabled(uiState, UI_ELEMENT.QUERY_INPUT_BOX);

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/Result.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/Result.tsx
@@ -37,6 +37,8 @@ const Result = ({logEventNum, message, matchRange}: ResultProps) => {
         message.slice(matchRange[1]),
     ];
     const handleResultButtonClick = () => {
+        const searchEvent = new CustomEvent("yscope/search", {});
+        document.dispatchEvent(searchEvent);
         updateWindowUrlHashParams({logEventNum});
     };
 

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
@@ -35,6 +35,11 @@ const SearchTabPanel = () => {
         setIsAllExpanded((v) => !v);
     };
 
+    const handleQueryChange = () => {
+        const clearSearchEvent = new CustomEvent("yscope/closeFind", {});
+        document.dispatchEvent(clearSearchEvent);
+    };
+
     return (
         <CustomTabPanel
             tabName={TAB_NAME.SEARCH}
@@ -53,7 +58,9 @@ const SearchTabPanel = () => {
             }
         >
             <Box className={"search-tab-container"}>
-                <QueryInputBox/>
+                <QueryInputBox onQueryChange={handleQueryChange}/>
+                {" "}
+                {/* Pass the handler to QueryInputBox */}
                 <AccordionGroup
                     className={"query-results"}
                     disableDivider={true}


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Fixes #189 

Search term highlighting enabled within a log event. Syncs the built in monaco editor find actions with the results from the log viewers search. 

- Basic search highlighting working
- Regex search result highlighting working 
- **Case sensitive Searches not working
->find action in monaco editor can take two arguments related to case sensitivity (matchCase and preserveCase). Both arguments take a boolean value. Setting either or both of them doesn't seem to trigger the case sensitivity in the monaco editor.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Loaded logs into the log viewer and attempt various searches to see that the correct terms were being highlighted in the log events with a match value.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
