### PR TITLE
fix(lint): Add `build/` directory to ESLint ignore patterns.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ import TsConfigArray, {createTsConfigOverride} from "eslint-config-yscope/TsConf
 const EslintConfig = [
     {
         ignores: [
+            "build/",
             "dist/",
             "node_modules/",
         ],


### PR DESCRIPTION
# Description

YScope dev infra related assets are generated in "/build":

https://github.com/y-scope/yscope-log-viewer/blob/75818f0b91accca1451375204fc20b24de2895a3/taskfile.yaml#L8

However, the linting configuration did not exclude the directory:

https://github.com/y-scope/yscope-log-viewer/blob/75818f0b91accca1451375204fc20b24de2895a3/eslint.config.mjs#L10-L13

The current lint:check would go crazy after log viewer docs are built under "build" folder. In this PR, we exclude this folder from ESLint lint check.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. `task docs:site`
2. `npm run lint` and observed the command exited successfully. Previously the command would fail, reporting errors for assets in the "/build" directory.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration to ignore the "build/" directory during linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->