### PR TITLE
docs: Add reference to YScope Discord server and clean up community server references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ![Open bug reports][bugs-shield]
 ![Open feature requests][feature-requests-shield]
-![CLP on Zulip][zulip-shield]
+[![Discord][badge-discord]][yscope-community-discord]
+[![CLP on Zulip][badge-zulip]][yscope-community-zulip]
 
 The YScope Log Viewer is a tool that can be used to view log files. It currently supports
 [CLP][clp-repo]'s compressed log files (IR streams) and JSON log files. The viewer can be used to
@@ -32,12 +33,19 @@ The log viewer's docs are available [here][docs-site].
 
 You can use GitHub issues to [report a bug][bug-report] or [request a feature][feature-req].
 
-Join us on [Zulip][zulip] to chat with developers and other community members.
+# Community
+
+Need help? Join us on one of our community servers:
+
+* [![Discord][badge-discord]][yscope-community-discord]
+* [![CLP on Zulip][badge-zulip]][yscope-community-zulip]
 
 # Contributing
 
 See the docs in our [developer guide][docs-site/dev-guide].
 
+[badge-discord]: https://img.shields.io/discord/1377353873068392580?style=flat&logo=discord&logoColor=white&label=Discord&labelColor=%235561f5
+[badge-zulip]: https://img.shields.io/badge/Zulip-yscope--clp-1888FA?logo=zulip
 [bug-report]: https://github.com/y-scope/yscope-log-viewer/issues/new?labels=bug&template=bug-report.yml
 [bugs-shield]: https://img.shields.io/github/issues/y-scope/yscope-log-viewer/bug?label=bugs
 [clp-repo]: https://github.com/y-scope/clp
@@ -51,5 +59,5 @@ See the docs in our [developer guide][docs-site/dev-guide].
 [feature-requests-shield]: https://img.shields.io/github/issues/y-scope/yscope-log-viewer/enhancement?label=feature-requests
 [hive-24hrs]: https://zenodo.org/records/7094921#.Y5JbH33MKHs
 [online-demo]: https://y-scope.github.io/yscope-log-viewer/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst
-[zulip]: https://yscope-clp.zulipchat.com/
-[zulip-shield]: https://img.shields.io/badge/zulip-yscope--clp%20chat-1888FA?logo=zulip
+[yscope-community-discord]: https://discord.gg/7kZA2m5G87
+[yscope-community-zulip]: https://yscope-clp.zulipchat.com

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,7 +53,12 @@ IR stream log files can currently be generated using these libraries:
 
 You can use GitHub issues to [report a bug][bug-report] or [request a feature][feature-req].
 
-Join us on [Zulip][zulip] to chat with developers and other community members.
+# Community
+
+Need help? Join us on one of our community servers:
+
+* [![Discord][badge-discord]][yscope-community-discord]
+* [![CLP on Zulip][badge-zulip]][yscope-community-zulip]
 
 # Features in development
 
@@ -73,6 +78,8 @@ user-guide/index
 dev-guide/index
 :::
 
+[badge-discord]: https://img.shields.io/discord/1377353873068392580?style=flat&logo=discord&logoColor=white&label=Discord&labelColor=%235561f5
+[badge-zulip]: https://img.shields.io/badge/Zulip-yscope--clp-1888FA?logo=zulip
 [bug-report]: https://github.com/y-scope/yscope-log-viewer/issues/new?labels=bug&template=bug-report.yml
 [clp-loglib-py]: https://github.com/y-scope/clp-loglib-py
 [clp-repo]: https://github.com/y-scope/clp
@@ -82,4 +89,5 @@ dev-guide/index
 [log4j1-appenders]: https://github.com/y-scope/log4j1-appenders
 [logback-appenders]: https://github.com/y-scope/logback-appenders
 [online-demo]: https://y-scope.github.io/yscope-log-viewer/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst
-[zulip]: https://yscope-clp.zulipchat.com/
+[yscope-community-discord]: https://discord.gg/7kZA2m5G87
+[yscope-community-zulip]: https://yscope-clp.zulipchat.com


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Copied from https://github.com/y-scope/clp/pull/964


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. `task docs:serve`
2. Accessed http://127.0.0.1:8080/ and verified the added links opened as expected.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README and documentation to feature both Discord and Zulip community badges and links.
  - Expanded the community section to highlight multiple ways for users to join and engage with the community.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->