### PR TITLE
fix: Set `overflow: hidden` on main layout; Remove margin adjustment for log-level-select (fixes #252).

### DIFF
--- a/src/components/StatusBar/LogLevelSelect/index.css
+++ b/src/components/StatusBar/LogLevelSelect/index.css
@@ -1,10 +1,3 @@
-.log-level-select {
-    /* JoyUI has a rounding issue when calculating the listbox position, causing it to misjudge if
-      the listbox will fit on the right side. To mitigate this, we shift the select box 1px to the
-      left. */
-    margin-right: 1px;
-}
-
 .log-level-select-render-value-box {
     display: flex;
     gap: 2px;

--- a/src/main.css
+++ b/src/main.css
@@ -1,6 +1,7 @@
 html,
 body,
 #root {
+    overflow: hidden;
     width: 100%;
     height: 100%;
     margin: 0;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

1. Set `overflow: hidden` on main layout: prevent scrollbars from showing up even when components overflows the view. This will fix #252 , where the "Prettify" button tooltip was observed to overflow the window view by ~1px.
2. Remove margin adjustment for log-level-select: the margin adjustment was a mitigation of the log-level-select listbox overflowing the window view by ~1px. Since now the "Prettity" is the rightmost button on the status bar, the listbox overflow issue is no longer reproducible anyways.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Changed the window zoom levels from 50% - 300% in increments my MS Edge browser permitted. For every level, hovered my mouse cursor onto the Prettify button and observed no scrollbar showing up around the window view.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed custom margin styling from the log level selector.
  - Updated main layout to prevent scrolling and hide overflow content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->