### PR TITLE
fix: Use JoyUI to present tooltip for "Open file" button.

### DIFF
--- a/src/components/MenuBar/index.tsx
+++ b/src/components/MenuBar/index.tsx
@@ -50,8 +50,8 @@ const MenuBar = () => {
                 <Divider orientation={"vertical"}/>
                 <MenuBarIconButton
                     disabled={isDisabled(uiState, UI_ELEMENT.OPEN_FILE_BUTTON)}
-                    title={"Open file"}
                     tooltipPlacement={"bottom-start"}
+                    tooltipTitle={"Open file"}
                     onClick={handleOpenFile}
                 >
                     <FolderOpenIcon className={"menu-bar-open-file-icon"}/>


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

as the title says. previously the tooltip was incorrectly displayed using browser's native tooltip.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Hovered onto the "Open file" button and observed the tooltip was displayed with JoyUI tooltip: 
![image](https://github.com/user-attachments/assets/98825355-cf4b-498f-9d43-432861db6d16)


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
