### PR TITLE
fix(url): Decode `filePath` before resolving into an absolute path (regressed by #286; fixes #329).

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -84,9 +84,9 @@ const parseWindowUrlSearchParams = () : Partial<UrlSearchParams> => {
         if (-1 !== filePathIndex) {
             const filePath = window.location.search.substring(filePathIndex + "filePath=".length);
             if (0 !== filePath.length) {
-                let resolvedFilePath = filePath;
+                let resolvedFilePath = decodeURIComponent(filePath);
                 try {
-                    resolvedFilePath = getAbsoluteUrl(filePath);
+                    resolvedFilePath = getAbsoluteUrl(resolvedFilePath);
                 } catch (e) {
                     console.error("Unable to get absolute URL from filePath:", e);
                 }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Call `decodeURIComponent()` to decode a potentially URL-encoded `filePath` before resolving the parameter value into an absolute path relative to the current host.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. URL-encoded the demo file link `https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst` -> `https%3A%2F%2Fyscope.s3.us-east-2.amazonaws.com%2Fsample-logs%2Fyarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst`.
2. Launched debug server and open the app in a browser. Use the URL-encoded link as the `filePath`. i.e., http://localhost:3010/?filePath=https%3A%2F%2Fyscope.s3.us-east-2.amazonaws.com%2Fsample-logs%2Fyarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst#logEventNum=375558
3. Observed the file was loaded successfully.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
