### PR TITLE
docs: Add zustand store action naming conventions dev guide (fixes #289).

### DIFF
--- a/docs/src/dev-guide/coding-guidelines.md
+++ b/docs/src/dev-guide/coding-guidelines.md
@@ -44,6 +44,12 @@ Examples:
 * `arrayIndexIdx` for a 0-based indexing variable.
 * `numEvents` for the total number of events.
 
+## Zustand store actions
+When implementing Zustand store actions, we follow these naming conventions:
+
+* Use `setX` for actions that simply change the value of a state.
+* Use `updateX` for actions that do more than simply changing a value (e.g., perform additional logic, make API calls, update multiple states).
+
 # React
 
 ## Omitting state variables from React Hooks


### PR DESCRIPTION
# Description
As the title says.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
run `task docs:site` & `task docs:serve`, the updated docs are shown.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
