### PR TITLE
refactor: Extract upper-bound binary search from `findNearestLogEventByTimestamp` into a function (resolves #343).

### DIFF
--- a/src/services/decoders/JsonlDecoder/index.ts
+++ b/src/services/decoders/JsonlDecoder/index.ts
@@ -18,6 +18,7 @@ import {
     LogLevelFilter,
 } from "../../../typings/logs";
 import {getNestedJsonValue} from "../../../utils/js";
+import {upperBoundBinarySearch} from "../../../utils/math";
 import YscopeFormatter from "../../formatters/YscopeFormatter";
 import {parseFilterKeys} from "../utils";
 import {
@@ -139,31 +140,12 @@ class JsonlDecoder implements Decoder {
     }
 
     findNearestLogEventByTimestamp (timestamp: number): Nullable<number> {
-        let low = 0;
-        let high = this.#logEvents.length - 1;
-        if (high < low) {
-            return null;
-        }
-
-        while (low <= high) {
-            const mid = Math.floor((low + high) / 2);
-
-            // `mid` is guaranteed to be within bounds since `low <= high`.
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const midTimestamp = this.#logEvents[mid]!.timestamp.valueOf();
-            if (midTimestamp <= timestamp) {
-                low = mid + 1;
-            } else {
-                high = mid - 1;
-            }
-        }
-
-        // corner case: all log events have timestamps >= timestamp
-        if (0 > high) {
-            return 0;
-        }
-
-        return high;
+        return upperBoundBinarySearch(
+            (idx) => this.#logEvents[idx]?.timestamp.valueOf(),
+            0,
+            this.#logEvents.length - 1,
+            timestamp
+        );
     }
 
     /**

--- a/src/services/decoders/JsonlDecoder/index.ts
+++ b/src/services/decoders/JsonlDecoder/index.ts
@@ -141,9 +141,9 @@ class JsonlDecoder implements Decoder {
 
     findNearestLogEventByTimestamp (timestamp: number): Nullable<number> {
         return upperBoundBinarySearch(
-            (logEvent) => logEvent.timestamp.valueOf(),
             this.#logEvents,
-            timestamp
+            timestamp,
+            (logEvent) => logEvent.timestamp.valueOf()
         );
     }
 

--- a/src/services/decoders/JsonlDecoder/index.ts
+++ b/src/services/decoders/JsonlDecoder/index.ts
@@ -141,9 +141,8 @@ class JsonlDecoder implements Decoder {
 
     findNearestLogEventByTimestamp (timestamp: number): Nullable<number> {
         return upperBoundBinarySearch(
-            (idx) => this.#logEvents[idx]?.timestamp.valueOf(),
-            0,
-            this.#logEvents.length - 1,
+            (logEvent) => logEvent.timestamp.valueOf(),
+            this.#logEvents,
             timestamp
         );
     }

--- a/src/services/decoders/JsonlDecoder/index.ts
+++ b/src/services/decoders/JsonlDecoder/index.ts
@@ -142,8 +142,8 @@ class JsonlDecoder implements Decoder {
     findNearestLogEventByTimestamp (timestamp: number): Nullable<number> {
         return upperBoundBinarySearch(
             this.#logEvents,
-            timestamp,
-            (logEvent) => logEvent.timestamp.valueOf()
+            (logEvent) => logEvent.timestamp.valueOf(),
+            timestamp
         );
     }
 

--- a/src/typings/decoders.ts
+++ b/src/typings/decoders.ts
@@ -128,7 +128,7 @@ interface Decoder {
      * behaviour.
      *
      * @param timestamp
-     * @return The index of the log event L.
+     * @return The index of the log event L, or null if there are no log events.
      */
     findNearestLogEventByTimestamp(timestamp: number): Nullable<number>;
 }

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -24,22 +24,22 @@ const getChunkNum =
     (itemNum: number, chunkSize: number) => Math.max(1, Math.ceil(itemNum / chunkSize));
 
 /**
- * Finds the index of the last element in a sorted collection that is less than or equal to
- * `upperboundValue`. If all elements in the collection are greater than `upperboundValue`, return
- * the first index of the collection (i.e., `0`).
+ * Finds the last element in a sorted collection that is less than or equal to `upperboundValue`. If
+ * all elements in the collection are greater than `upperboundValue`, returns the first index of the
+ * collection (i.e., `0`).
  *
- * @param get Function provided to access elements in the collection by index.
+ * @param get Function to access elements in the collection by index.
  * @param lowIdx
  * @param highIdx
- * @param upperboundValue
- * @return The index of the last element less than or equal to `upperboundValue`,`0` if all elements
- * are greater, or `null` if the collection is empty or the indices are invalid.
+ * @param upperBoundValue
+ * @return The index of the last element less than or equal to `upperboundValue`, `0` if all
+ * elements are greater, or `null` if the collection is empty or the indices are invalid.
  */
 const upperBoundBinarySearch = <T>(
     get: (index: number) => T,
     lowIdx: number,
     highIdx: number,
-    upperboundValue: T,
+    upperBoundValue: T,
 ): Nullable<number> => {
     if (highIdx < lowIdx || "undefined" === typeof (get(highIdx))) {
         return null;
@@ -49,7 +49,7 @@ const upperBoundBinarySearch = <T>(
         const mid = Math.floor((lowIdx + highIdx) / 2);
 
         // `mid` is guaranteed to be within bounds since `low <= high`.
-        if (get(mid) <= upperboundValue) {
+        if (get(mid) <= upperBoundValue) {
             lowIdx = mid + 1;
         } else {
             highIdx = mid - 1;

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -35,7 +35,7 @@ const getChunkNum =
  * elements are greater, or `null` if the collection is empty or the indices are invalid.
  */
 const upperBoundBinarySearch = <T, U>(
-    get: (logEvent: U) => T,
+    get: (arrayElement: U) => T,
     array: U[],
     upperBoundValue: T,
 ): Nullable<number> => {

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -24,32 +24,33 @@ const getChunkNum =
     (itemNum: number, chunkSize: number) => Math.max(1, Math.ceil(itemNum / chunkSize));
 
 /**
- * Finds the last element in a sorted collection that is less than or equal to `upperboundValue`. If
- * all elements in the collection are greater than `upperboundValue`, returns the first index of the
+ * Finds the last element in a sorted collection that is less than or equal to `upperBoundValue`. If
+ * all elements in the collection are greater than `upperBoundValue`, returns the first index of the
  * collection (i.e., `0`).
  *
- * @param get Function to access elements in the collection by index.
- * @param lowIdx
- * @param highIdx
+ * @param get Function to access an element (or its property) in the collection.
+ * @param array
  * @param upperBoundValue
- * @return The index of the last element less than or equal to `upperboundValue`, `0` if all
+ * @return The index of the last element less than or equal to `upperBoundValue`, `0` if all
  * elements are greater, or `null` if the collection is empty or the indices are invalid.
  */
-const upperBoundBinarySearch = <T>(
-    get: (index: number) => T,
-    lowIdx: number,
-    highIdx: number,
+const upperBoundBinarySearch = <T, U>(
+    get: (logEvent: U) => T,
+    array: U[],
     upperBoundValue: T,
 ): Nullable<number> => {
-    if (highIdx < lowIdx || "undefined" === typeof (get(highIdx))) {
+    if (0 === array.length) {
         return null;
     }
+    let lowIdx = 0;
+    let highIdx = array.length - 1;
 
     while (lowIdx <= highIdx) {
         const mid = Math.floor((lowIdx + highIdx) / 2);
 
         // `mid` is guaranteed to be within bounds since `low <= high`.
-        if (get(mid) <= upperBoundValue) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        if (get(array[mid]!) <= upperBoundValue) {
             lowIdx = mid + 1;
         } else {
             highIdx = mid - 1;

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -32,7 +32,7 @@ const getChunkNum =
  * @param upperBoundValue
  * @param get Function to access an element (or its property) in the collection.
  * @return The index of the last element less than or equal to `upperBoundValue`, `0` if all
- * elements are greater, or `null` if the collection is empty or the indices are invalid.
+ * elements are greater, or `null` if the collection is empty.
  */
 const upperBoundBinarySearch = <T, U>(
     array: U[],

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,4 +1,4 @@
-import {Nullable} from "../typings/common.ts";
+import {Nullable} from "../typings/common";
 
 
 /**

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -40,7 +40,7 @@ const upperBoundBinarySearch = <T>(
     highIdx: number,
     upperboundValue: T,
 ): Nullable<number> => {
-    if (highIdx < lowIdx) {
+    if (highIdx < lowIdx || "undefined" === typeof (get(highIdx))) {
         return null;
     }
 

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -48,7 +48,7 @@ const upperBoundBinarySearch = <T, U>(
     while (lowIdx <= highIdx) {
         const mid = Math.floor((lowIdx + highIdx) / 2);
 
-        // `mid` is guaranteed to be within bounds since `low <= high`.
+        // `mid` is guaranteed to be within bounds since `lowIdx <= highIdx`.
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         if (get(array[mid]!) <= upperBoundValue) {
             lowIdx = mid + 1;

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -24,33 +24,33 @@ const getChunkNum =
     (itemNum: number, chunkSize: number) => Math.max(1, Math.ceil(itemNum / chunkSize));
 
 /**
- * Finds the last element in a sorted collection that is less than or equal to `upperBoundValue`. If
- * all elements in the collection are greater than `upperBoundValue`, returns the first index of the
- * collection (i.e., `0`).
+ * Finds the last element in a sorted collection, `collection`, that is less than or equal to
+ * `upperBoundValue`. If all elements in the collection are greater than `upperBoundValue`, returns
+ * `0` (index of the first element in the collection).
  *
- * @param array The entire collection in ascending order.
- * @param upperBoundValue
+ * @param collection The collection sorted in ascending order.
  * @param get Function to access an element (or its property) in the collection.
+ * @param upperBoundValue
  * @return The index of the last element less than or equal to `upperBoundValue`, `0` if all
  * elements are greater, or `null` if the collection is empty.
  */
 const upperBoundBinarySearch = <T, U>(
-    array: U[],
-    upperBoundValue: T,
+    collection: U[],
     get: (arrayElement: U) => T,
+    upperBoundValue: T,
 ): Nullable<number> => {
-    if (0 === array.length) {
+    if (0 === collection.length) {
         return null;
     }
     let lowIdx = 0;
-    let highIdx = array.length - 1;
+    let highIdx = collection.length - 1;
 
     while (lowIdx <= highIdx) {
         const mid = Math.floor((lowIdx + highIdx) / 2);
 
         // `mid` is guaranteed to be within bounds since `lowIdx <= highIdx`.
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        if (get(array[mid]!) <= upperBoundValue) {
+        if (get(collection[mid]!) <= upperBoundValue) {
             lowIdx = mid + 1;
         } else {
             highIdx = mid - 1;

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -28,11 +28,12 @@ const getChunkNum =
  * `upperboundValue`. If all elements in the collection are greater than `upperboundValue`, return
  * the first index of the collection (i.e., `0`).
  *
- * @param get
+ * @param get Function provided to access elements in the collection by index.
  * @param lowIdx
  * @param highIdx
  * @param upperboundValue
- * @return
+ * @return The index of the last element less than or equal to `upperboundValue`,`0` if all elements
+ * are greater, or `null` if the collection is empty or the indices are invalid.
  */
 const upperBoundBinarySearch = <T>(
     get: (index: number) => T,

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,3 +1,6 @@
+import {Nullable} from "../typings/common.ts";
+
+
 /**
  * Clamps a number to the given range. E.g. If the number is greater than the range's upper bound,
  * the range's upper bound is returned.
@@ -20,7 +23,48 @@ const clamp = (num: number, min: number, max: number) => Math.min(Math.max(num, 
 const getChunkNum =
     (itemNum: number, chunkSize: number) => Math.max(1, Math.ceil(itemNum / chunkSize));
 
+/**
+ * Finds the index of the last element in a sorted collection that is less than or equal to
+ * `upperboundValue`. If all elements in the collection are greater than `upperboundValue`, return
+ * the first index of the collection (i.e., `0`).
+ *
+ * @param get
+ * @param lowIdx
+ * @param highIdx
+ * @param upperboundValue
+ * @return
+ */
+const upperBoundBinarySearch = <T>(
+    get: (index: number) => T,
+    lowIdx: number,
+    highIdx: number,
+    upperboundValue: T,
+): Nullable<number> => {
+    if (highIdx < lowIdx) {
+        return null;
+    }
+
+    while (lowIdx <= highIdx) {
+        const mid = Math.floor((lowIdx + highIdx) / 2);
+
+        // `mid` is guaranteed to be within bounds since `low <= high`.
+        if (get(mid) <= upperboundValue) {
+            lowIdx = mid + 1;
+        } else {
+            highIdx = mid - 1;
+        }
+    }
+
+    // corner case: all values >= upperboundValue
+    if (0 > highIdx) {
+        return 0;
+    }
+
+    return highIdx;
+};
+
 export {
     clamp,
     getChunkNum,
+    upperBoundBinarySearch,
 };

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -28,16 +28,16 @@ const getChunkNum =
  * all elements in the collection are greater than `upperBoundValue`, returns the first index of the
  * collection (i.e., `0`).
  *
- * @param get Function to access an element (or its property) in the collection.
- * @param array
+ * @param array The entire collection in ascending order.
  * @param upperBoundValue
+ * @param get Function to access an element (or its property) in the collection.
  * @return The index of the last element less than or equal to `upperBoundValue`, `0` if all
  * elements are greater, or `null` if the collection is empty or the indices are invalid.
  */
 const upperBoundBinarySearch = <T, U>(
-    get: (arrayElement: U) => T,
     array: U[],
     upperBoundValue: T,
+    get: (arrayElement: U) => T,
 ): Nullable<number> => {
     if (0 === array.length) {
         return null;

--- a/test/utils/math.test.ts
+++ b/test/utils/math.test.ts
@@ -24,7 +24,7 @@ describe("clamp", () => {
     });
 
     test(
-        "returns the upper boundary when the upper boundary is less than the lower boundary",
+        "returns the upper boundary if the upper boundary is less than the lower boundary",
         () => {
             expect(clamp(5, 10, 1)).toBe(1);
         }
@@ -56,48 +56,48 @@ describe("upperBoundBinarySearch", () => {
     const emptyArray: number[] = [];
     const singleElementArray = [3];
     const array = [-5, -3, 0, 1, 1, 8, 8, 8, 100];
-    test("returns null for empty collection with fake highIdx", () => {
+    test("returns null if collection is empty with lowIdx < highIdx", () => {
         const result = upperBoundBinarySearch((idx) => emptyArray[idx], 0, 1, 5);
         expect(result).toBeNull();
     });
-    test("returns null for empty collection with valid highIdx", () => {
+    test("returns null if collection is empty with highIdx < lowIdx", () => {
         const result = upperBoundBinarySearch((idx) => emptyArray[idx], 0, -1, 5);
         expect(result).toBeNull();
     });
-    test("returns the first index for upperboundValue < all elements in array", () => {
+    test("returns the first index if upperboundValue < all elements in array", () => {
         const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, -10);
         expect(result).toBe(0);
     });
-    test("returns the first index for upperboundValue < element in singleElementArray", () => {
+    test("returns the first index if upperboundValue < element in singleElementArray", () => {
         const result = upperBoundBinarySearch((idx) => singleElementArray[idx], 0, 0, -10);
         expect(result).toBe(0);
     });
-    test("returns the last index for upperboundValue > all elements in array", () => {
+    test("returns the last index if upperboundValue > all elements in array", () => {
         const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 200);
         expect(result).toBe(array.length - 1);
     });
-    test("returns the last index for upperboundValue > element in singleElementArray", () => {
+    test("returns the last index if upperboundValue > element in singleElementArray", () => {
         const result = upperBoundBinarySearch((idx) => singleElementArray[idx], 0, 0, 200);
         expect(result).toBe(0);
     });
-    test("returns the index for upperboundValue doesn't exactly match any elements", () => {
+    test("returns the correct index if upperboundValue doesn't match any elements", () => {
         const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 2);
         expect(result).toBe(4);
     });
-    test("returns the index for upperboundValue matches a unique element", () => {
+    test("returns the correct index if upperboundValue matches a unique element", () => {
         const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 0);
         expect(result).toBe(2);
     });
-    test("returns the index for upperboundValue matches a duplicated element", () => {
+    test("returns the last matched index if upperboundValue matches a duplicated element", () => {
         const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 8);
         expect(result).toBe(7);
     });
-    test("returns the first element index", () => {
+    test("returns index 0 if upperboundValue matches the first element", () => {
         const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, -5);
         expect(result).toBe(0);
     });
-    test("returns the last element index", () => {
+    test("returns the last index if upperboundValue matches the last element", () => {
         const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 100);
-        expect(result).toBe(8);
+        expect(result).toBe(array.length - 1);
     });
 });

--- a/test/utils/math.test.ts
+++ b/test/utils/math.test.ts
@@ -1,6 +1,8 @@
+/* eslint-disable @stylistic/array-element-newline */
 import {
     clamp,
     getChunkNum,
+    upperBoundBinarySearch,
 } from "../../src/utils/math";
 
 
@@ -47,5 +49,51 @@ describe("getChunkNum", () => {
         expect(getChunkNum(10, 2)).toBe(5);
         expect(getChunkNum(15, 3)).toBe(5);
         expect(getChunkNum(20, 4)).toBe(5);
+    });
+});
+
+describe("upperBoundBinarySearch", () => {
+    const emptyArray: number[] = [];
+    const singleElementArray = [3];
+    const array = [-5, -3, 0, 1, 8, 100];
+    test("returns null for empty collection with fake highIdx", () => {
+        const result = upperBoundBinarySearch((idx) => emptyArray[idx], 0, 1, 5);
+        expect(result).toBeNull();
+    });
+    test("returns null for empty collection with valid highIdx", () => {
+        const result = upperBoundBinarySearch((idx) => emptyArray[idx], 0, -1, 5);
+        expect(result).toBeNull();
+    });
+    test("returns the first index for upperboundValue < all elements in array", () => {
+        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 5);
+        expect(result).toBe(0);
+    });
+    test("returns the first index for upperboundValue < elements in singleElementArray", () => {
+        const result = upperBoundBinarySearch((idx) => singleElementArray[idx], 0, 0, 5);
+        expect(result).toBe(0);
+    });
+    test("returns the last index for upperboundValue >= all elements in array", () => {
+        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 200);
+        expect(result).toBe(array.length - 1);
+    });
+    test("returns the last index for upperboundValue >= elements in singleElementArray", () => {
+        const result = upperBoundBinarySearch((idx) => singleElementArray[idx], 0, 0, 3);
+        expect(result).toBe(0);
+    });
+    test("returns the index for upperboundValue doesn't exactly match any element", () => {
+        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 2);
+        expect(result).toBe(3);
+    });
+    test("returns the index for upperboundValue matches an element", () => {
+        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 8);
+        expect(result).toBe(4);
+    });
+    test("returns the index for upperboundValue matches the first element", () => {
+        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, -5);
+        expect(result).toBe(0);
+    });
+    test("returns the index for upperboundValue matches the last element", () => {
+        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 100);
+        expect(result).toBe(5);
     });
 });

--- a/test/utils/math.test.ts
+++ b/test/utils/math.test.ts
@@ -60,11 +60,11 @@ describe("upperBoundBinarySearch", () => {
         const result = upperBoundBinarySearch(emptyArray, 5, (arrayElement) => arrayElement);
         expect(result).toBeNull();
     });
-    test("returns the first index if upperboundValue < all elements in array", () => {
+    test("returns the first index if upperBoundValue < all elements in array", () => {
         const result = upperBoundBinarySearch(array, -10, (arrayElement) => arrayElement);
         expect(result).toBe(0);
     });
-    test("returns the first index if upperboundValue < element in singleElementArray", () => {
+    test("returns the first index if upperBoundValue < element in singleElementArray", () => {
         const result = upperBoundBinarySearch(
             singleElementArray,
             -10,
@@ -73,11 +73,11 @@ describe("upperBoundBinarySearch", () => {
 
         expect(result).toBe(0);
     });
-    test("returns the last index if upperboundValue > all elements in array", () => {
+    test("returns the last index if upperBoundValue > all elements in array", () => {
         const result = upperBoundBinarySearch(array, 200, (arrayElement) => arrayElement);
         expect(result).toBe(array.length - 1);
     });
-    test("returns the last index if upperboundValue > element in singleElementArray", () => {
+    test("returns the last index if upperBoundValue > element in singleElementArray", () => {
         const result = upperBoundBinarySearch(
             singleElementArray,
             200,
@@ -86,23 +86,23 @@ describe("upperBoundBinarySearch", () => {
 
         expect(result).toBe(0);
     });
-    test("returns the correct index if upperboundValue doesn't match any elements", () => {
+    test("returns the correct index if upperBoundValue doesn't match any elements", () => {
         const result = upperBoundBinarySearch(array, 2, (arrayElement) => arrayElement);
         expect(result).toBe(4);
     });
-    test("returns the correct index if upperboundValue matches a unique element", () => {
+    test("returns the correct index if upperBoundValue matches a unique element", () => {
         const result = upperBoundBinarySearch(array, 0, (arrayElement) => arrayElement);
         expect(result).toBe(2);
     });
-    test("returns the last matched index if upperboundValue matches a duplicated element", () => {
+    test("returns the last matched index if upperBoundValue matches a duplicated element", () => {
         const result = upperBoundBinarySearch(array, 8, (arrayElement) => arrayElement);
         expect(result).toBe(7);
     });
-    test("returns index 0 if upperboundValue matches the first element", () => {
+    test("returns index 0 if upperBoundValue matches the first element", () => {
         const result = upperBoundBinarySearch(array, -5, (arrayElement) => arrayElement);
         expect(result).toBe(0);
     });
-    test("returns the last index if upperboundValue matches the last element", () => {
+    test("returns the last index if upperBoundValue matches the last element", () => {
         const result = upperBoundBinarySearch(array, 100, (arrayElement) => arrayElement);
         expect(result).toBe(array.length - 1);
     });

--- a/test/utils/math.test.ts
+++ b/test/utils/math.test.ts
@@ -55,7 +55,7 @@ describe("getChunkNum", () => {
 describe("upperBoundBinarySearch", () => {
     const emptyArray: number[] = [];
     const singleElementArray = [3];
-    const array = [-5, -3, 0, 1, 8, 100];
+    const array = [-5, -3, 0, 1, 1, 8, 8, 8, 100];
     test("returns null for empty collection with fake highIdx", () => {
         const result = upperBoundBinarySearch((idx) => emptyArray[idx], 0, 1, 5);
         expect(result).toBeNull();
@@ -65,35 +65,39 @@ describe("upperBoundBinarySearch", () => {
         expect(result).toBeNull();
     });
     test("returns the first index for upperboundValue < all elements in array", () => {
-        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 5);
+        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, -10);
         expect(result).toBe(0);
     });
-    test("returns the first index for upperboundValue < elements in singleElementArray", () => {
-        const result = upperBoundBinarySearch((idx) => singleElementArray[idx], 0, 0, 5);
+    test("returns the first index for upperboundValue < element in singleElementArray", () => {
+        const result = upperBoundBinarySearch((idx) => singleElementArray[idx], 0, 0, -10);
         expect(result).toBe(0);
     });
-    test("returns the last index for upperboundValue >= all elements in array", () => {
+    test("returns the last index for upperboundValue > all elements in array", () => {
         const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 200);
         expect(result).toBe(array.length - 1);
     });
-    test("returns the last index for upperboundValue >= elements in singleElementArray", () => {
-        const result = upperBoundBinarySearch((idx) => singleElementArray[idx], 0, 0, 3);
+    test("returns the last index for upperboundValue > element in singleElementArray", () => {
+        const result = upperBoundBinarySearch((idx) => singleElementArray[idx], 0, 0, 200);
         expect(result).toBe(0);
     });
-    test("returns the index for upperboundValue doesn't exactly match any element", () => {
+    test("returns the index for upperboundValue doesn't exactly match any elements", () => {
         const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 2);
-        expect(result).toBe(3);
-    });
-    test("returns the index for upperboundValue matches an element", () => {
-        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 8);
         expect(result).toBe(4);
     });
-    test("returns the index for upperboundValue matches the first element", () => {
+    test("returns the index for upperboundValue matches a unique element", () => {
+        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 0);
+        expect(result).toBe(2);
+    });
+    test("returns the index for upperboundValue matches a duplicated element", () => {
+        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 8);
+        expect(result).toBe(7);
+    });
+    test("returns the first element index", () => {
         const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, -5);
         expect(result).toBe(0);
     });
-    test("returns the index for upperboundValue matches the last element", () => {
+    test("returns the last element index", () => {
         const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 100);
-        expect(result).toBe(5);
+        expect(result).toBe(8);
     });
 });

--- a/test/utils/math.test.ts
+++ b/test/utils/math.test.ts
@@ -57,53 +57,53 @@ describe("upperBoundBinarySearch", () => {
     const singleElementArray = [3];
     const array = [-5, -3, 0, 1, 1, 8, 8, 8, 100];
     test("returns null if collection is empty", () => {
-        const result = upperBoundBinarySearch(emptyArray, 5, (arrayElement) => arrayElement);
+        const result = upperBoundBinarySearch(emptyArray, (arrayElement) => arrayElement, 5);
         expect(result).toBeNull();
     });
     test("returns the first index if upperBoundValue < all elements in array", () => {
-        const result = upperBoundBinarySearch(array, -10, (arrayElement) => arrayElement);
+        const result = upperBoundBinarySearch(array, (arrayElement) => arrayElement, -10);
         expect(result).toBe(0);
     });
     test("returns the first index if upperBoundValue < element in singleElementArray", () => {
         const result = upperBoundBinarySearch(
             singleElementArray,
-            -10,
-            (arrayElement) => arrayElement
+            (arrayElement) => arrayElement,
+            -10
         );
 
         expect(result).toBe(0);
     });
     test("returns the last index if upperBoundValue > all elements in array", () => {
-        const result = upperBoundBinarySearch(array, 200, (arrayElement) => arrayElement);
+        const result = upperBoundBinarySearch(array, (arrayElement) => arrayElement, 200);
         expect(result).toBe(array.length - 1);
     });
     test("returns the last index if upperBoundValue > element in singleElementArray", () => {
         const result = upperBoundBinarySearch(
             singleElementArray,
-            200,
-            (arrayElement) => arrayElement
+            (arrayElement) => arrayElement,
+            200
         );
 
         expect(result).toBe(0);
     });
     test("returns the correct index if upperBoundValue doesn't match any elements", () => {
-        const result = upperBoundBinarySearch(array, 2, (arrayElement) => arrayElement);
+        const result = upperBoundBinarySearch(array, (arrayElement) => arrayElement, 2);
         expect(result).toBe(4);
     });
     test("returns the correct index if upperBoundValue matches a unique element", () => {
-        const result = upperBoundBinarySearch(array, 0, (arrayElement) => arrayElement);
+        const result = upperBoundBinarySearch(array, (arrayElement) => arrayElement, 0);
         expect(result).toBe(2);
     });
     test("returns the last matched index if upperBoundValue matches a duplicated element", () => {
-        const result = upperBoundBinarySearch(array, 8, (arrayElement) => arrayElement);
+        const result = upperBoundBinarySearch(array, (arrayElement) => arrayElement, 8);
         expect(result).toBe(7);
     });
     test("returns index 0 if upperBoundValue matches the first element", () => {
-        const result = upperBoundBinarySearch(array, -5, (arrayElement) => arrayElement);
+        const result = upperBoundBinarySearch(array, (arrayElement) => arrayElement, -5);
         expect(result).toBe(0);
     });
     test("returns the last index if upperBoundValue matches the last element", () => {
-        const result = upperBoundBinarySearch(array, 100, (arrayElement) => arrayElement);
+        const result = upperBoundBinarySearch(array, (arrayElement) => arrayElement, 100);
         expect(result).toBe(array.length - 1);
     });
 });

--- a/test/utils/math.test.ts
+++ b/test/utils/math.test.ts
@@ -56,11 +56,7 @@ describe("upperBoundBinarySearch", () => {
     const emptyArray: number[] = [];
     const singleElementArray = [3];
     const array = [-5, -3, 0, 1, 1, 8, 8, 8, 100];
-    test("returns null if collection is empty with lowIdx < highIdx", () => {
-        const result = upperBoundBinarySearch(emptyArray, 5, (arrayElement) => arrayElement);
-        expect(result).toBeNull();
-    });
-    test("returns null if collection is empty with highIdx < lowIdx", () => {
+    test("returns null if collection is empty", () => {
         const result = upperBoundBinarySearch(emptyArray, 5, (arrayElement) => arrayElement);
         expect(result).toBeNull();
     });

--- a/test/utils/math.test.ts
+++ b/test/utils/math.test.ts
@@ -24,7 +24,7 @@ describe("clamp", () => {
     });
 
     test(
-        "returns the upper boundary if the upper boundary is less than the lower boundary",
+        "returns the upper boundary when the upper boundary is less than the lower boundary",
         () => {
             expect(clamp(5, 10, 1)).toBe(1);
         }

--- a/test/utils/math.test.ts
+++ b/test/utils/math.test.ts
@@ -57,47 +57,57 @@ describe("upperBoundBinarySearch", () => {
     const singleElementArray = [3];
     const array = [-5, -3, 0, 1, 1, 8, 8, 8, 100];
     test("returns null if collection is empty with lowIdx < highIdx", () => {
-        const result = upperBoundBinarySearch((idx) => emptyArray[idx], 0, 1, 5);
+        const result = upperBoundBinarySearch((arrayElement) => arrayElement, emptyArray, 5);
         expect(result).toBeNull();
     });
     test("returns null if collection is empty with highIdx < lowIdx", () => {
-        const result = upperBoundBinarySearch((idx) => emptyArray[idx], 0, -1, 5);
+        const result = upperBoundBinarySearch((arrayElement) => arrayElement, emptyArray, 5);
         expect(result).toBeNull();
     });
     test("returns the first index if upperboundValue < all elements in array", () => {
-        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, -10);
+        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, -10);
         expect(result).toBe(0);
     });
     test("returns the first index if upperboundValue < element in singleElementArray", () => {
-        const result = upperBoundBinarySearch((idx) => singleElementArray[idx], 0, 0, -10);
+        const result = upperBoundBinarySearch(
+            (arrayElement) => arrayElement,
+            singleElementArray,
+            -10
+        );
+
         expect(result).toBe(0);
     });
     test("returns the last index if upperboundValue > all elements in array", () => {
-        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 200);
+        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, 200);
         expect(result).toBe(array.length - 1);
     });
     test("returns the last index if upperboundValue > element in singleElementArray", () => {
-        const result = upperBoundBinarySearch((idx) => singleElementArray[idx], 0, 0, 200);
+        const result = upperBoundBinarySearch(
+            (arrayElement) => arrayElement,
+            singleElementArray,
+            200
+        );
+
         expect(result).toBe(0);
     });
     test("returns the correct index if upperboundValue doesn't match any elements", () => {
-        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 2);
+        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, 2);
         expect(result).toBe(4);
     });
     test("returns the correct index if upperboundValue matches a unique element", () => {
-        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 0);
+        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, 0);
         expect(result).toBe(2);
     });
     test("returns the last matched index if upperboundValue matches a duplicated element", () => {
-        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 8);
+        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, 8);
         expect(result).toBe(7);
     });
     test("returns index 0 if upperboundValue matches the first element", () => {
-        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, -5);
+        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, -5);
         expect(result).toBe(0);
     });
     test("returns the last index if upperboundValue matches the last element", () => {
-        const result = upperBoundBinarySearch((idx) => array[idx], 0, array.length - 1, 100);
+        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, 100);
         expect(result).toBe(array.length - 1);
     });
 });

--- a/test/utils/math.test.ts
+++ b/test/utils/math.test.ts
@@ -57,57 +57,57 @@ describe("upperBoundBinarySearch", () => {
     const singleElementArray = [3];
     const array = [-5, -3, 0, 1, 1, 8, 8, 8, 100];
     test("returns null if collection is empty with lowIdx < highIdx", () => {
-        const result = upperBoundBinarySearch((arrayElement) => arrayElement, emptyArray, 5);
+        const result = upperBoundBinarySearch(emptyArray, 5, (arrayElement) => arrayElement);
         expect(result).toBeNull();
     });
     test("returns null if collection is empty with highIdx < lowIdx", () => {
-        const result = upperBoundBinarySearch((arrayElement) => arrayElement, emptyArray, 5);
+        const result = upperBoundBinarySearch(emptyArray, 5, (arrayElement) => arrayElement);
         expect(result).toBeNull();
     });
     test("returns the first index if upperboundValue < all elements in array", () => {
-        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, -10);
+        const result = upperBoundBinarySearch(array, -10, (arrayElement) => arrayElement);
         expect(result).toBe(0);
     });
     test("returns the first index if upperboundValue < element in singleElementArray", () => {
         const result = upperBoundBinarySearch(
-            (arrayElement) => arrayElement,
             singleElementArray,
-            -10
+            -10,
+            (arrayElement) => arrayElement
         );
 
         expect(result).toBe(0);
     });
     test("returns the last index if upperboundValue > all elements in array", () => {
-        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, 200);
+        const result = upperBoundBinarySearch(array, 200, (arrayElement) => arrayElement);
         expect(result).toBe(array.length - 1);
     });
     test("returns the last index if upperboundValue > element in singleElementArray", () => {
         const result = upperBoundBinarySearch(
-            (arrayElement) => arrayElement,
             singleElementArray,
-            200
+            200,
+            (arrayElement) => arrayElement
         );
 
         expect(result).toBe(0);
     });
     test("returns the correct index if upperboundValue doesn't match any elements", () => {
-        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, 2);
+        const result = upperBoundBinarySearch(array, 2, (arrayElement) => arrayElement);
         expect(result).toBe(4);
     });
     test("returns the correct index if upperboundValue matches a unique element", () => {
-        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, 0);
+        const result = upperBoundBinarySearch(array, 0, (arrayElement) => arrayElement);
         expect(result).toBe(2);
     });
     test("returns the last matched index if upperboundValue matches a duplicated element", () => {
-        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, 8);
+        const result = upperBoundBinarySearch(array, 8, (arrayElement) => arrayElement);
         expect(result).toBe(7);
     });
     test("returns index 0 if upperboundValue matches the first element", () => {
-        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, -5);
+        const result = upperBoundBinarySearch(array, -5, (arrayElement) => arrayElement);
         expect(result).toBe(0);
     });
     test("returns the last index if upperboundValue matches the last element", () => {
-        const result = upperBoundBinarySearch((arrayElement) => arrayElement, array, 100);
+        const result = upperBoundBinarySearch(array, 100, (arrayElement) => arrayElement);
         expect(result).toBe(array.length - 1);
     });
 });


### PR DESCRIPTION
# Description

This pull request refactors the `findNearestLogEventByTimestamp` method in the `JsonlDecoder` class by introducing a reusable utility function, `upperBoundBinarySearch`, to simplify and optimize the binary search logic. Additionally, it includes unit tests for the new utility function. Below is a summary of the most important changes:

### Refactoring and Optimization:

* The `findNearestLogEventByTimestamp` core binary search logic in `JsonlDecoder` was refactored to use the newly introduced `upperBoundBinarySearch` utility function, replacing the inline binary search implementation. This improves code readability and reusability.

### Testing:

* Added comprehensive unit tests for `upperBoundBinarySearch` in `test/utils/math.test.ts`, covering edge cases such as empty arrays, single-element arrays, and arrays with duplicate values.

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* Passed all tests with command `npx jest test/utils/math.test.ts`
* Tried this timestamp query on log viewer: http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst#timestamp=1427103813789 and it jumps to the correct log event number with timestamp Mon Mar 23 2015 09:43:33.789 GMT.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Nearest-log-event lookup now uses a shared upper-bound binary-search utility for clearer, more maintainable behaviour.

* **New Features**
  * Added a reusable upper-bound binary-search utility for efficient lookups on sorted collections.

* **Tests**
  * Added comprehensive tests for the new utility covering empty inputs, edge cases, boundaries and duplicates.

* **Documentation**
  * Clarified that the log-event lookup may return null when no events exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->