### PR TITLE
fix: Apply url hash parameter configuration during file load (fixes #348).

### DIFF
--- a/src/components/AppController.tsx
+++ b/src/components/AppController.tsx
@@ -86,7 +86,6 @@ const getCursorFromHashParams = ({isPrettified, logEventNum, timestamp}: {
  * NOTE: this may modify the URL parameters.
  */
 const updateViewHashParams = () => {
-    console.error("updateViewHashParams gets called");
     const {isPrettified, logEventNum, timestamp} = getWindowUrlHashParams();
     updateWindowUrlHashParams({
         isPrettified: URL_HASH_PARAMS_DEFAULT.isPrettified,
@@ -184,9 +183,10 @@ const AppController = ({children}: AppControllerProps) => {
         // Handle initial page load and maintain full URL state
         handleHashChange(null);
         const hashParams = getWindowUrlHashParams();
-
-        // TODO: update isPrettified here
-        console.warn("AppController: Initial hash params", hashParams);
+        updateWindowUrlHashParams({
+            isPrettified: URL_HASH_PARAMS_DEFAULT.isPrettified,
+            timestamp: URL_HASH_PARAMS_DEFAULT.timestamp,
+        });
         const searchParams = getWindowUrlSearchParams();
         if (URL_SEARCH_PARAMS_DEFAULT.filePath !== searchParams.filePath) {
             let cursor: CursorType = {code: CURSOR_CODE.LAST_EVENT, args: null};
@@ -202,6 +202,8 @@ const AppController = ({children}: AppControllerProps) => {
                     args: {eventNum: hashParams.logEventNum},
                 };
             }
+            const {setIsPrettified} = useViewStore.getState();
+            setIsPrettified(hashParams.isPrettified);
             const {loadFile} = useLogFileStore.getState();
             loadFile(searchParams.filePath, cursor);
         }

--- a/src/components/AppController.tsx
+++ b/src/components/AppController.tsx
@@ -86,6 +86,7 @@ const getCursorFromHashParams = ({isPrettified, logEventNum, timestamp}: {
  * NOTE: this may modify the URL parameters.
  */
 const updateViewHashParams = () => {
+    console.error("updateViewHashParams gets called");
     const {isPrettified, logEventNum, timestamp} = getWindowUrlHashParams();
     updateWindowUrlHashParams({
         isPrettified: URL_HASH_PARAMS_DEFAULT.isPrettified,
@@ -144,15 +145,15 @@ const updateQueryHashParams = () => {
  * @param [ev] The hash change event, or `null` when called on application initialization.
  */
 const handleHashChange = (ev: Nullable<HashChangeEvent>) => {
+    if (null === ev) {
+        // If this is called on app initialization, we don't need to update the query params.
+        return;
+    }
     updateViewHashParams();
-    const isTriggeredByHashChange = null !== ev;
-    if (isTriggeredByHashChange && updateQueryHashParams()) {
+    if (updateQueryHashParams()) {
         const {startQuery} = useQueryStore.getState();
         startQuery();
     }
-
-    // eslint-disable-next-line no-warning-comments
-    // TODO: Remove empty or falsy parameters.
 };
 
 interface AppControllerProps {
@@ -183,6 +184,9 @@ const AppController = ({children}: AppControllerProps) => {
         // Handle initial page load and maintain full URL state
         handleHashChange(null);
         const hashParams = getWindowUrlHashParams();
+
+        // TODO: update isPrettified here
+        console.warn("AppController: Initial hash params", hashParams);
         const searchParams = getWindowUrlSearchParams();
         if (URL_SEARCH_PARAMS_DEFAULT.filePath !== searchParams.filePath) {
             let cursor: CursorType = {code: CURSOR_CODE.LAST_EVENT, args: null};

--- a/src/stores/viewStore/createViewFormattingSlice.ts
+++ b/src/stores/viewStore/createViewFormattingSlice.ts
@@ -31,6 +31,9 @@ const createViewFormattingSlice: StateCreator<
     ViewState, [], [], ViewFormattingSlice
 > = (set, get) => ({
     ...VIEW_FORMATTING_DEFAULT,
+    setIsPrettified: (isPrettified: boolean) => {
+        set({isPrettified});
+    },
     updateIsPrettified: (newIsPrettified: boolean) => {
         const {isPrettified} = get();
         if (newIsPrettified === isPrettified) {

--- a/src/stores/viewStore/types.ts
+++ b/src/stores/viewStore/types.ts
@@ -36,6 +36,7 @@ interface ViewFormattingValues {
 }
 
 interface ViewFormattingActions {
+    setIsPrettified: (isPrettified: boolean) => void;
     updateIsPrettified: (newIsPrettified: boolean) => void;
 }
 


### PR DESCRIPTION
# Description
Fixes #348.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
Open log viewer with http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst#logEventNum=10&isPrettified=true

Notice that the log event number is set to 10, and prettify is enabled.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app initialization to prevent unnecessary query updates and ensure default URL hash parameters are set on load.
  * Ensured the view state for prettified display is correctly synchronized with URL parameters when loading files.

* **New Features**
  * Added a method to directly set the prettified view state, allowing for more precise control over display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->