### PR TITLE
feat(ci): Trigger docs GH workflow only when related files are altered.

### DIFF
--- a/.github/workflows/log-viewer-docs.yaml
+++ b/.github/workflows/log-viewer-docs.yaml
@@ -2,7 +2,7 @@ name: "docs"
 
 on:
   pull_request:
-    paths:
+    paths: &docs_paths
       - "docs/**"
       - ".github/workflows/log-viewer-docs.yaml"
       - ".gitmodules"
@@ -10,13 +10,7 @@ on:
       - "tools/scripts/**"
       - "tools/yscope-dev-utils"
   push:
-    paths:
-      - "docs/**"
-      - ".github/workflows/log-viewer-docs.yaml"
-      - ".gitmodules"
-      - "taskfile.yaml"
-      - "tools/scripts/**"
-      - "tools/yscope-dev-utils"
+    paths: *docs_paths
   schedule:
     # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
     - cron: "15 0 * * *"

--- a/.github/workflows/log-viewer-docs.yaml
+++ b/.github/workflows/log-viewer-docs.yaml
@@ -2,7 +2,7 @@ name: "docs"
 
 on:
   pull_request:
-    paths: &docs_paths
+    paths: &monitored_paths
       - "docs/**"
       - ".github/workflows/log-viewer-docs.yaml"
       - ".gitmodules"
@@ -10,7 +10,7 @@ on:
       - "tools/scripts/**"
       - "tools/yscope-dev-utils"
   push:
-    paths: *docs_paths
+    paths: *monitored_paths
   schedule:
     # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
     - cron: "15 0 * * *"

--- a/.github/workflows/log-viewer-docs.yaml
+++ b/.github/workflows/log-viewer-docs.yaml
@@ -3,8 +3,18 @@ name: "docs"
 on:
   pull_request:
     paths:
-        - "docs/**"
+        - docs/**/*
+        - .github/workflows/log-viewer-docs.yaml
+        - .gitmodules
+        - taskfile.yaml
+        - tools/**/*
   push:
+    paths:
+      - docs/**/*
+      - .github/workflows/log-viewer-docs.yaml
+      - .gitmodules
+      - taskfile.yaml
+      - tools/**/*
   schedule:
     # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
     - cron: "15 0 * * *"

--- a/.github/workflows/log-viewer-docs.yaml
+++ b/.github/workflows/log-viewer-docs.yaml
@@ -2,6 +2,8 @@ name: "docs"
 
 on:
   pull_request:
+    paths:
+        - "docs/**"
   push:
   schedule:
     # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)

--- a/.github/workflows/log-viewer-docs.yaml
+++ b/.github/workflows/log-viewer-docs.yaml
@@ -3,18 +3,20 @@ name: "docs"
 on:
   pull_request:
     paths:
-        - docs/**/*
-        - .github/workflows/log-viewer-docs.yaml
-        - .gitmodules
-        - taskfile.yaml
-        - tools/**/*
+      - "docs/**"
+      - ".github/workflows/log-viewer-docs.yaml"
+      - ".gitmodules"
+      - "taskfile.yaml"
+      - "tools/scripts/**"
+      - "tools/yscope-dev-utils"
   push:
     paths:
-      - docs/**/*
-      - .github/workflows/log-viewer-docs.yaml
-      - .gitmodules
-      - taskfile.yaml
-      - tools/**/*
+      - "docs/**"
+      - ".github/workflows/log-viewer-docs.yaml"
+      - ".gitmodules"
+      - "taskfile.yaml"
+      - "tools/scripts/**"
+      - "tools/yscope-dev-utils"
   schedule:
     # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
     - cron: "15 0 * * *"


### PR DESCRIPTION
# Description
Continuation of #352.
This pull request updates the workflow triggers for the `log-viewer-docs` GitHub Actions workflow to include additional paths for both `pull_request` and `push` events.

### Workflow trigger updates:
* `.github/workflows/log-viewer-docs.yaml`: Modified the `pull_request` and `push` event triggers to monitor changes in the following paths:
  - `docs/**`
  - `.github/workflows/log-viewer-docs.yaml`
  - `.gitmodules`
  - `taskfile.yaml`
  - `tools/**`



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Check the following two PRs after the branch is merged to main:
The docs workflow history is shown here: https://github.com/Henry8192/yscope-log-viewer/actions/workflows/log-viewer-docs.yaml
* Changes outside monitored folder: https://github.com/Henry8192/yscope-log-viewer/pull/4, notice that docs / build workflow  is not triggered;
* Changes inside monitored folder: https://github.com/Henry8192/yscope-log-viewer/actions/runs/17111213521, notice that docs / build workflow is triggered.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Optimized CI so documentation- and tooling-related workflows now only run when relevant files change, reducing unnecessary pipeline runs and improving efficiency. Scheduled and other triggers remain unchanged. No impact on application features or documentation content; this streamlines feedback for docs/tooling updates and lowers CI noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->