### PR TITLE
docs: Update minimum required Task version to 3.40.0 in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ this project:
     the size of repo as we add and update images.
 * [Node.js] >= 16 to be able to [view the output](#viewing-the-output)
 * Python 3.10 or later
-* [Task] >= 3.38.0
+* [Task] >= 3.40.0
 
 ## Build commands
 


### PR DESCRIPTION
# Description

Change the task minimum required version to 3.40.0 according to https://github.com/y-scope/clp/pull/1158.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
Notice that the README task minimum version changes to 3.40.0.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
