### PR TITLE
fix: Add back button that jumps to settings tab in format pop up message (fixes #341).

### DIFF
--- a/src/stores/logFileStore.ts
+++ b/src/stores/logFileStore.ts
@@ -14,6 +14,7 @@ import {
     QueryResults,
 } from "../typings/query";
 import {UI_STATE} from "../typings/states";
+import {TAB_NAME} from "../typings/tab";
 import {SEARCH_PARAM_NAMES} from "../typings/url";
 import {
     CursorType,
@@ -54,12 +55,24 @@ const LOG_FILE_STORE_DEFAULT: LogFileValues = {
 };
 
 /**
+ * Handles the primary action of the format popup by switching to the settings tab.
+ */
+const handleFormatPopupPrimaryAction = () => {
+    const {setActiveTabName} = useUiStore.getState();
+    setActiveTabName(TAB_NAME.SETTINGS);
+};
+
+/**
  * Format popup message shown when a structured log is loaded without a format string.
  */
 const FORMAT_POP_UP_MESSAGE: PopUpMessage = Object.freeze({
     level: LOG_LEVEL.INFO,
     message: "Adding a format string can enhance the readability of your" +
                     " structured logs by customizing how fields are displayed.",
+    primaryAction: {
+        children: "Settings",
+        onClick: handleFormatPopupPrimaryAction,
+    },
     timeoutMillis: LONG_AUTO_DISMISS_TIMEOUT_MILLIS,
     title: "A format string has not been configured",
 });


### PR DESCRIPTION
# Description
Fixes #341.

# Checklist
* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
Load log viewer with [example.zip](https://github.com/user-attachments/files/21719937/example.zip) unzipped. Notice that the button that navigates to settings tab is back.
<img width="706" height="308" alt="image" src="https://github.com/user-attachments/assets/49ad52db-ff52-40ce-96f8-7b06f75ab948" />





[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
