### PR TITLE
feat: Auto-switch to Search tab when query parameters are present in URL (resolves #331).

### DIFF
--- a/src/stores/queryStore/createQueryControllerSlice.ts
+++ b/src/stores/queryStore/createQueryControllerSlice.ts
@@ -1,7 +1,9 @@
 import {StateCreator} from "zustand";
 
+import {TAB_NAME} from "../../typings/tab";
 import useLogFileManagerStore from "../logFileManagerProxyStore";
 import {handleErrorWithNotification} from "../notificationStore";
+import useUiStore from "../uiStore";
 import {QUERY_CONFIG_DEFAULT} from "./createQueryConfigSlice.ts";
 import {QUERY_RESULTS_DEFAULT} from "./createQueryResultsSlice";
 import {
@@ -50,6 +52,9 @@ const createQueryControllerSlice: StateCreator<
 
             await logFileManagerProxy.startQuery(queryString, queryIsRegex, queryIsCaseSensitive);
         })().catch(handleErrorWithNotification);
+
+        const {setActiveTabName} = useUiStore.getState();
+        setActiveTabName(TAB_NAME.SEARCH);
     },
 });
 


### PR DESCRIPTION
# Description
Resolves #331.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
0. Open log viewer, make sure side bar tab is not in Search tab.
1. Load http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst#queryString=123 in the log viewer, notice side bar switches to search tab automatically.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
