### PR TITLE
fix: Add back percent-decoding for filePath URL parameter (fixes #329).

### DIFF
--- a/src/utils/url/index.ts
+++ b/src/utils/url/index.ts
@@ -77,9 +77,9 @@ const parseWindowUrlSearchParams = () : Partial<UrlSearchParams> => {
         if (-1 !== filePathIndex) {
             const filePath = window.location.search.substring(filePathIndex + "filePath=".length);
             if (0 !== filePath.length) {
-                let resolvedFilePath = filePath;
+                let resolvedFilePath = decodeURIComponent(filePath);
                 try {
-                    resolvedFilePath = getAbsoluteUrl(filePath);
+                    resolvedFilePath = getAbsoluteUrl(resolvedFilePath);
                 } catch (e) {
                     console.error("Unable to get absolute URL from filePath:", e);
                 }


### PR DESCRIPTION
# Description

Fixes #329.


# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
Open log viewer with % encoded link: http://localhost:3010/?filePath=https%3A%2F%2Fyscope.s3.us-east-2.amazonaws.com%2Fsample-logs%2Fyarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst#logEventNum=375558, observe that the link opens successfully.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
