### PR TITLE
refactor: Create async function `loadPageByCursor` for code reduction; Centralize `uiState` change in `loadPageByCursor` (fixes #355).

### DIFF
--- a/src/components/AppController.tsx
+++ b/src/components/AppController.tsx
@@ -106,11 +106,11 @@ const AppController = ({children}: AppControllerProps) => {
                 await loadFile(searchParams.filePath);
                 const {loadPageByCursor} = useViewStore.getState();
                 await loadPageByCursor(getInitialCursor(hashParams));
+                if (updateQueryHashParams()) {
+                    const {startQuery} = useQueryStore.getState();
+                    startQuery();
+                }
             })().catch(handleErrorWithNotification);
-            if (updateQueryHashParams()) {
-                const {startQuery} = useQueryStore.getState();
-                startQuery();
-            }
         }
 
         return () => {

--- a/src/components/DropFileContainer/index.tsx
+++ b/src/components/DropFileContainer/index.tsx
@@ -4,7 +4,9 @@ import React, {
 } from "react";
 
 import useLogFileStore from "../../stores/logFileStore";
+import {handleErrorWithNotification} from "../../stores/notificationStore";
 import useUiStore from "../../stores/uiStore";
+import useViewStore from "../../stores/viewStore";
 import {UI_ELEMENT} from "../../typings/states";
 import {CURSOR_CODE} from "../../typings/worker";
 import {isDisabled} from "../../utils/states";
@@ -66,8 +68,12 @@ const DropFileContainer = ({children}: DropFileContextProviderProps) => {
 
             return;
         }
-        const {loadFile} = useLogFileStore.getState();
-        loadFile(file, {code: CURSOR_CODE.LAST_EVENT, args: null});
+        (async () => {
+            const {loadFile} = useLogFileStore.getState();
+            await loadFile(file);
+            const {loadPageByCursor} = useViewStore.getState();
+            await loadPageByCursor({code: CURSOR_CODE.LAST_EVENT, args: null});
+        })().catch(handleErrorWithNotification);
     }, [disabled]);
 
     return (

--- a/src/components/MenuBar/index.tsx
+++ b/src/components/MenuBar/index.tsx
@@ -11,7 +11,9 @@ import {
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 
 import useLogFileStore from "../../stores/logFileStore";
+import {handleErrorWithNotification} from "../../stores/notificationStore";
 import useUiStore from "../../stores/uiStore";
+import useViewStore from "../../stores/viewStore";
 import {UI_ELEMENT} from "../../typings/states";
 import {CURSOR_CODE} from "../../typings/worker";
 import {openFile} from "../../utils/file";
@@ -34,8 +36,12 @@ const MenuBar = () => {
 
     const handleOpenFile = useCallback(() => {
         openFile((file) => {
-            const {loadFile} = useLogFileStore.getState();
-            loadFile(file, {code: CURSOR_CODE.LAST_EVENT, args: null});
+            (async () => {
+                const {loadFile} = useLogFileStore.getState();
+                await loadFile(file);
+                const {loadPageByCursor} = useViewStore.getState();
+                await loadPageByCursor({code: CURSOR_CODE.LAST_EVENT, args: null});
+            })().catch(handleErrorWithNotification);
         });
     }, []);
 

--- a/src/components/StatusBar/index.tsx
+++ b/src/components/StatusBar/index.tsx
@@ -14,10 +14,7 @@ import AutoFixOffIcon from "@mui/icons-material/AutoFixOff";
 import useLogFileStore from "../../stores/logFileStore";
 import useUiStore from "../../stores/uiStore";
 import useViewStore from "../../stores/viewStore";
-import {
-    UI_ELEMENT,
-    UI_STATE,
-} from "../../typings/states";
+import {UI_ELEMENT} from "../../typings/states";
 import {HASH_PARAM_NAMES} from "../../typings/url";
 import {ACTION_NAME} from "../../utils/actions";
 import {isDisabled} from "../../utils/states";
@@ -58,7 +55,6 @@ const StatusBar = () => {
                 updateWindowUrlHashParams({
                     [HASH_PARAM_NAMES.IS_PRETTIFIED]: false === isPrettified,
                 });
-                useUiStore.getState().setUiState(UI_STATE.FAST_LOADING);
                 updateViewHashParams();
                 break;
             default:

--- a/src/stores/logFileStore.ts
+++ b/src/stores/logFileStore.ts
@@ -108,7 +108,6 @@ const handleQueryResults = (progress: number, results: QueryResults) => {
 
 const useLogFileStore = create<LogFileState>((set) => ({
     ...LOG_FILE_STORE_DEFAULT,
-    // eslint-disable-next-line max-statements
     loadFile: async (fileSrc: FileSrcType) => {
         const {setUiState} = useUiStore.getState();
         setUiState(UI_STATE.FILE_LOADING);
@@ -135,10 +134,6 @@ const useLogFileStore = create<LogFileState>((set) => ({
             pageNum: VIEW_PAGE_DEFAULT.pageNum,
         });
 
-        set({fileSrc});
-        if ("string" !== typeof fileSrc) {
-            updateWindowUrlSearchParams({[SEARCH_PARAM_NAMES.FILE_PATH]: null});
-        }
         const {logFileManagerProxy} = useLogFileManagerProxyStore.getState();
         const decoderOptions = getConfig(CONFIG_KEY.DECODER_OPTIONS);
         const fileInfo = await logFileManagerProxy.loadFile(

--- a/src/stores/viewStore/createViewPageSlice.ts
+++ b/src/stores/viewStore/createViewPageSlice.ts
@@ -103,10 +103,14 @@ const createViewPageSlice: StateCreator<
                     )}, logEventNum=${logEventNum} when reloading.`
                 );
             }
-            loadFile(fileSrc, {
-                code: CURSOR_CODE.EVENT_NUM,
-                args: {eventNum: logEventNum},
-            });
+            (async () => {
+                await loadFile(fileSrc);
+                const {loadPageByCursor} = get();
+                await loadPageByCursor({
+                    code: CURSOR_CODE.EVENT_NUM,
+                    args: {eventNum: logEventNum},
+                });
+            })().catch(handleErrorWithNotification);
 
             return;
         }

--- a/src/stores/viewStore/createViewPageSlice.ts
+++ b/src/stores/viewStore/createViewPageSlice.ts
@@ -130,12 +130,14 @@ const createViewPageSlice: StateCreator<
         const {setUiState} = useUiStore.getState();
         setUiState(UI_STATE.FAST_LOADING);
 
-        const {logFileManagerProxy} = useLogFileManagerStore.getState();
-        const pageData = await logFileManagerProxy.loadPage(cursor);
-        const {updatePageData} = get();
-        updatePageData(pageData);
-
-        setUiState(UI_STATE.READY);
+        try {
+            const {logFileManagerProxy} = useLogFileManagerStore.getState();
+            const pageData = await logFileManagerProxy.loadPage(cursor);
+            const {updatePageData} = get();
+            updatePageData(pageData);
+        } finally {
+            setUiState(UI_STATE.READY);
+        }
     },
     updatePageData: (pageData: PageData) => {
         set({

--- a/src/stores/viewStore/createViewPageSlice.ts
+++ b/src/stores/viewStore/createViewPageSlice.ts
@@ -92,17 +92,6 @@ const createViewPageSlice: StateCreator<
     ViewState, [], [], ViewPageSlice
 > = (set, get) => ({
     ...VIEW_PAGE_DEFAULT,
-    loadPage: async (cursor: CursorType) => {
-        const {setUiState} = useUiStore.getState();
-        setUiState(UI_STATE.FAST_LOADING);
-
-        const {logFileManagerProxy} = useLogFileManagerStore.getState();
-        const pageData = await logFileManagerProxy.loadPage(cursor);
-        const {updatePageData} = get();
-        updatePageData(pageData);
-
-        setUiState(UI_STATE.READY);
-    },
     loadPageByAction: (navAction: NavigationAction) => {
         if (navAction.code === ACTION_NAME.RELOAD) {
             const {fileSrc, loadFile} = useLogFileStore.getState();
@@ -128,14 +117,25 @@ const createViewPageSlice: StateCreator<
 
             return;
         }
-        const {numPages, pageNum, loadPage} = get();
+        const {numPages, pageNum, loadPageByCursor} = get();
         const cursor = getPageNumCursor(navAction, pageNum, numPages);
         if (null === cursor) {
             console.error(`Error with nav action ${navAction.code}.`);
 
             return;
         }
-        loadPage(cursor).catch(handleErrorWithNotification);
+        loadPageByCursor(cursor).catch(handleErrorWithNotification);
+    },
+    loadPageByCursor: async (cursor: CursorType) => {
+        const {setUiState} = useUiStore.getState();
+        setUiState(UI_STATE.FAST_LOADING);
+
+        const {logFileManagerProxy} = useLogFileManagerStore.getState();
+        const pageData = await logFileManagerProxy.loadPage(cursor);
+        const {updatePageData} = get();
+        updatePageData(pageData);
+
+        setUiState(UI_STATE.READY);
     },
     updatePageData: (pageData: PageData) => {
         set({

--- a/src/stores/viewStore/createViewPageSlice.ts
+++ b/src/stores/viewStore/createViewPageSlice.ts
@@ -126,7 +126,7 @@ const createViewPageSlice: StateCreator<
         }
         loadPageByCursor(cursor).catch(handleErrorWithNotification);
     },
-    loadPageByCursor: (cursor: CursorType) => {
+    loadPageByCursor: async (cursor: CursorType) => {
         const {setUiState} = useUiStore.getState();
         setUiState(UI_STATE.FAST_LOADING);
 

--- a/src/stores/viewStore/types.ts
+++ b/src/stores/viewStore/types.ts
@@ -15,7 +15,7 @@ interface ViewPageValues {
 }
 
 interface ViewPageActions {
-    loadPage: (cursor: CursorType) => Promise<void>;
+    loadPageByCursor: (cursor: CursorType) => Promise<void>;
     loadPageByAction: (navAction: NavigationAction) => void;
     updatePageData: (pageData: PageData) => void;
 }

--- a/src/stores/viewStore/types.ts
+++ b/src/stores/viewStore/types.ts
@@ -1,6 +1,7 @@
 import {LogLevelFilter} from "../../typings/logs";
 import {
     BeginLineNumToLogEventNumMap,
+    CursorType,
     PageData,
 } from "../../typings/worker";
 import {NavigationAction} from "../../utils/actions";
@@ -14,6 +15,7 @@ interface ViewPageValues {
 }
 
 interface ViewPageActions {
+    loadPage: (cursor: CursorType) => Promise<void>;
     loadPageByAction: (navAction: NavigationAction) => void;
     updatePageData: (pageData: PageData) => void;
 }

--- a/src/utils/url/urlHash.ts
+++ b/src/utils/url/urlHash.ts
@@ -97,8 +97,8 @@ const updateViewHashParams = () => {
         return;
     }
 
-    const {loadPage} = useViewStore.getState();
-    loadPage(cursor).catch(handleErrorWithNotification);
+    const {loadPageByCursor} = useViewStore.getState();
+    loadPageByCursor(cursor).catch(handleErrorWithNotification);
 };
 
 /**

--- a/src/utils/url/urlHash.ts
+++ b/src/utils/url/urlHash.ts
@@ -2,10 +2,8 @@ import useLogFileManagerProxyStore from "../../stores/logFileManagerProxyStore.t
 import useLogFileStore from "../../stores/logFileStore.ts";
 import {handleErrorWithNotification} from "../../stores/notificationStore.ts";
 import useQueryStore from "../../stores/queryStore";
-import useUiStore from "../../stores/uiStore";
 import useViewStore from "../../stores/viewStore";
 import {Nullable} from "../../typings/common";
-import {UI_STATE} from "../../typings/states";
 import {
     CURSOR_CODE,
     CursorType,
@@ -38,10 +36,19 @@ const getCursorFromHashParams = ({isPrettified, logEventNum, timestamp}: {
         return null;
     }
 
-    const {isPrettified: prevIsPrettified, setLogEventNum} = useViewStore.getState();
+    const {
+        isPrettified: prevIsPrettified, setIsPrettified, setLogEventNum,
+    } = useViewStore.getState();
     const clampedLogEventNum = clamp(logEventNum, 1, numEvents);
 
     if (isPrettified !== prevIsPrettified) {
+        setIsPrettified(isPrettified);
+
+        (async () => {
+            const {logFileManagerProxy} = useLogFileManagerProxyStore.getState();
+            await logFileManagerProxy.setIsPrettified(isPrettified);
+        })().catch(handleErrorWithNotification);
+
         return {
             code: CURSOR_CODE.EVENT_NUM,
             args: {eventNum: clampedLogEventNum},
@@ -90,19 +97,8 @@ const updateViewHashParams = () => {
         return;
     }
 
-    (async () => {
-        const {logFileManagerProxy} = useLogFileManagerProxyStore.getState();
-        const {updatePageData} = useViewStore.getState();
-        const {isPrettified: prevIsPrettified, setIsPrettified} = useViewStore.getState();
-        if (isPrettified !== prevIsPrettified) {
-            setIsPrettified(isPrettified);
-            await logFileManagerProxy.setIsPrettified(isPrettified);
-        }
-        const pageData = await logFileManagerProxy.loadPage(cursor);
-        updatePageData(pageData);
-        const {setUiState} = useUiStore.getState();
-        setUiState(UI_STATE.READY);
-    })().catch(handleErrorWithNotification);
+    const {loadPage} = useViewStore.getState();
+    loadPage(cursor).catch(handleErrorWithNotification);
 };
 
 /**


### PR DESCRIPTION
# Description

Fixes #355.

This pull request refactors how page loading and UI state management are handled in the log viewer application. The main changes involve moving the responsibility for setting UI loading states and fetching page data into a new asynchronous `loadPage` action within the view store, which simplifies navigation logic and improves code organization.

**Refactoring and code organization:**

* Added a new asynchronous `loadPage` method to `ViewPageActions` in `src/stores/viewStore/types.ts`, centralizing page loading logic and UI state management.
* Refactored `createViewPageSlice` in `src/stores/viewStore/createViewPageSlice.ts` to use `loadPage` for both direct page loads and navigation actions, removing duplicated UI state handling and page data updates.
* Updated `updateViewHashParams` and related logic in `src/utils/url/urlHash.ts` to use the new `loadPage` method, further simplifying async page loading and UI state transitions.

**Simplification and cleanup:**

* Removed unnecessary imports and direct UI state updates in `src/components/StatusBar/index.tsx`, relying on the new centralized logic.
* Improved prettified view toggling logic in `src/utils/url/urlHash.ts` by updating state and proxy settings in a more streamlined way.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Open log viewer with link http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst

## `loadPageByCursor` test
Only `updateViewHashParams` and `loadPageByAction` calls `loadPageByCursor`, by verifying these two functions we can confirm `loadPageByCursor` is working.

- In url, enter http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst#logEventNum=30001, the page loads successfully.
- Press next page button in navigation bar, the page loads successfully.

## `uiState` test
In `uiStore.ts`, replace the code with this snippet:
```ts
const useUiStore = create<UiStoreState>((set, get) => ({
    ...UI_STORE_DEFAULT,
    setActiveTabName: (tabName) => {
        set({activeTabName: tabName});
    },
    setUiState: (newUIState: UI_STATE) => {
        console.error(`Setting UI state from ${get().uiState} to ${newUIState}`);
        set({uiState: newUIState});
    },
}));
```
- First page, previous page, change page number, next page, last page and toggle prettified button all shows
```log
uiStore.ts:32 Setting UI state from 3 to 2
uiStore.ts:32 Setting UI state from 2 to 3
```
where 3 is READY state and 2 is FAST_LOADING state.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Prettify now applies immediately, stays synced with the URL and backend, and persists across loads.

- Bug Fixes
  - Toggling prettify no longer shows spurious loading indicators.
  - File open, drag‑drop and URL-driven loads surface errors via notifications and reliably navigate to the intended event.

- Refactor
  - Initial load and page-loading flows reworked into centralized, fully asynchronous two-step sequences (file load, then page navigation) for more reliable behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->