### PR TITLE
fix: Allow `PlainTextDecoder` fallback by removing empty signature check.

### DIFF
--- a/src/services/LogFileManager/decodeUtils.ts
+++ b/src/services/LogFileManager/decodeUtils.ts
@@ -61,7 +61,7 @@ const tryCreateDecoderBySignature = async (
     decoderOptions: DecoderOptions
 ): Promise<Nullable<{decoder: Decoder; fileTypeDef: FileTypeDef}>> => {
     for (const entry of FILE_TYPE_DEFINITIONS) {
-        if (0 === entry.signature.length || fileData.length < entry.signature.length) {
+        if (fileData.length < entry.signature.length) {
             continue;
         }
 


### PR DESCRIPTION
# Description
Currently log viewer will crash when throwing any plain text files that are not ".err", ".log", ".out", ".txt". We should try to decode the provided files as a plain text file as a fallback.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
Open log viewer with https://raw.githubusercontent.com/y-scope/yscope-log-viewer/refs/heads/main/README.md, the file can be successfully opened.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved automatic detection of certain log files that use empty or minimal signatures, allowing them to be decoded instead of being skipped.
  - Reduced false negatives in format detection, increasing compatibility with a broader range of log files.
  - Refined error-handling during decoder selection to avoid prematurely skipping valid options, leading to more consistent outcomes when opening edge-case files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->