### PR TITLE
fix(editor): Ensure page reloads after toggling prettify state (fixes #379).

### DIFF
--- a/docs/src/dev-guide/contributing-validation.md
+++ b/docs/src/dev-guide/contributing-validation.md
@@ -39,6 +39,6 @@ still be tested manually:
   * Exporting all logs to a file
   * Toggling tabbed panels in the sidebar
   * Using keyboard shortcuts
-  * Toggling "Prettify" in both the status bar and the address bar
+  * Toggling "Prettify" via the status bar button, the address bar (URL hash), and Monaco action
 
 [gh-workflow-test]: https://github.com/y-scope/yscope-log-viewer/blob/main/.github/workflows/test.yaml

--- a/docs/src/dev-guide/contributing-validation.md
+++ b/docs/src/dev-guide/contributing-validation.md
@@ -39,6 +39,6 @@ still be tested manually:
   * Exporting all logs to a file
   * Toggling tabbed panels in the sidebar
   * Using keyboard shortcuts
-  * Toggling "Prettify" via the status bar button, the address bar (URL hash), and Monaco action
+  * Toggling "Prettify" via the status bar button, the address bar (URL hash), and the Monaco action
 
 [gh-workflow-test]: https://github.com/y-scope/yscope-log-viewer/blob/main/.github/workflows/test.yaml

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -10,10 +10,10 @@ import {
 import {useColorScheme} from "@mui/joy";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 
-import {handleErrorWithNotification} from "../../stores/notificationStore.ts";
+import {handleErrorWithNotification} from "../../stores/notificationStore";
 import useQueryStore from "../../stores/queryStore";
 import useViewStore from "../../stores/viewStore";
-import {togglePrettify} from "../../stores/viewStore/createViewFormattingSlice.ts";
+import {togglePrettify} from "../../stores/viewStore/createViewFormattingSlice";
 import {Nullable} from "../../typings/common";
 import {
     CONFIG_KEY,

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -10,7 +10,6 @@ import {
 import {useColorScheme} from "@mui/joy";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 
-import {handleErrorWithNotification} from "../../stores/notificationStore";
 import useQueryStore from "../../stores/queryStore";
 import useViewStore from "../../stores/viewStore";
 import {togglePrettify} from "../../stores/viewStore/createViewFormattingSlice";
@@ -164,9 +163,7 @@ const handleEditorCustomAction = (
             break;
         }
         case ACTION_NAME.TOGGLE_PRETTIFY: {
-            (async () => {
-                await togglePrettify();
-            })().catch(handleErrorWithNotification);
+            togglePrettify();
             break;
         }
         case ACTION_NAME.TOGGLE_WORD_WRAP:

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -12,7 +12,6 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 
 import useQueryStore from "../../stores/queryStore";
 import useViewStore from "../../stores/viewStore";
-import {togglePrettify} from "../../stores/viewStore/createViewFormattingSlice";
 import {Nullable} from "../../typings/common";
 import {
     CONFIG_KEY,
@@ -33,7 +32,10 @@ import {
     getMapValueWithNearestLessThanOrEqualKey,
 } from "../../utils/data";
 import {updateWindowUrlHashParams} from "../../utils/url";
-import {updateViewHashParams} from "../../utils/url/urlHash";
+import {
+    togglePrettify,
+    updateViewHashParams,
+} from "../../utils/url/urlHash";
 import MonacoInstance from "./MonacoInstance";
 import {goToPositionAndCenter} from "./MonacoInstance/utils";
 

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -10,14 +10,15 @@ import {
 import {useColorScheme} from "@mui/joy";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 
+import {handleErrorWithNotification} from "../../stores/notificationStore.ts";
 import useQueryStore from "../../stores/queryStore";
 import useViewStore from "../../stores/viewStore";
+import {togglePrettify} from "../../stores/viewStore/createViewFormattingSlice.ts";
 import {Nullable} from "../../typings/common";
 import {
     CONFIG_KEY,
     THEME_NAME,
 } from "../../typings/config";
-import {HASH_PARAM_NAMES} from "../../typings/url";
 import {BeginLineNumToLogEventNumMap} from "../../typings/worker";
 import {
     ACTION_NAME,
@@ -163,13 +164,9 @@ const handleEditorCustomAction = (
             break;
         }
         case ACTION_NAME.TOGGLE_PRETTIFY: {
-            const {isPrettified, setIsPrettified} = useViewStore.getState();
-            const newIsPrettified = !isPrettified;
-            updateWindowUrlHashParams({
-                [HASH_PARAM_NAMES.IS_PRETTIFIED]: newIsPrettified,
-            });
-            setIsPrettified(newIsPrettified);
-            updateViewHashParams();
+            (async () => {
+                await togglePrettify();
+            })().catch(handleErrorWithNotification);
             break;
         }
         case ACTION_NAME.TOGGLE_WORD_WRAP:

--- a/src/components/StatusBar/index.tsx
+++ b/src/components/StatusBar/index.tsx
@@ -12,11 +12,11 @@ import AutoFixOffIcon from "@mui/icons-material/AutoFixOff";
 import useLogFileStore from "../../stores/logFileStore";
 import useUiStore from "../../stores/uiStore";
 import useViewStore from "../../stores/viewStore";
-import {togglePrettify} from "../../stores/viewStore/createViewFormattingSlice";
 import {UI_ELEMENT} from "../../typings/states";
 import {ACTION_NAME} from "../../utils/actions";
 import {isDisabled} from "../../utils/states";
 import {copyPermalinkToClipboard} from "../../utils/url";
+import {togglePrettify} from "../../utils/url/urlHash";
 import LogLevelSelect from "./LogLevelSelect";
 import StatusBarToggleButton from "./StatusBarToggleButton";
 

--- a/src/components/StatusBar/index.tsx
+++ b/src/components/StatusBar/index.tsx
@@ -12,7 +12,6 @@ import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import AutoFixOffIcon from "@mui/icons-material/AutoFixOff";
 
 import useLogFileStore from "../../stores/logFileStore";
-import {handleErrorWithNotification} from "../../stores/notificationStore";
 import useUiStore from "../../stores/uiStore";
 import useViewStore from "../../stores/viewStore";
 import {togglePrettify} from "../../stores/viewStore/createViewFormattingSlice";
@@ -45,7 +44,7 @@ const StatusBar = () => {
     const uiState = useUiStore((state) => state.uiState);
 
     const handlePrettifyToggle = useCallback(() => {
-        togglePrettify().catch(handleErrorWithNotification);
+        togglePrettify();
     }, []);
 
     const isPrettifyButtonDisabled = isDisabled(uiState, UI_ELEMENT.PRETTIFY_BUTTON);

--- a/src/components/StatusBar/index.tsx
+++ b/src/components/StatusBar/index.tsx
@@ -12,10 +12,10 @@ import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import AutoFixOffIcon from "@mui/icons-material/AutoFixOff";
 
 import useLogFileStore from "../../stores/logFileStore";
-import {handleErrorWithNotification} from "../../stores/notificationStore.ts";
+import {handleErrorWithNotification} from "../../stores/notificationStore";
 import useUiStore from "../../stores/uiStore";
 import useViewStore from "../../stores/viewStore";
-import {togglePrettify} from "../../stores/viewStore/createViewFormattingSlice.ts";
+import {togglePrettify} from "../../stores/viewStore/createViewFormattingSlice";
 import {UI_ELEMENT} from "../../typings/states";
 import {ACTION_NAME} from "../../utils/actions";
 import {isDisabled} from "../../utils/states";

--- a/src/components/StatusBar/index.tsx
+++ b/src/components/StatusBar/index.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from "react";
+import {useCallback} from "react";
 
 import {
     Button,
@@ -12,17 +12,14 @@ import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import AutoFixOffIcon from "@mui/icons-material/AutoFixOff";
 
 import useLogFileStore from "../../stores/logFileStore";
+import {handleErrorWithNotification} from "../../stores/notificationStore.ts";
 import useUiStore from "../../stores/uiStore";
 import useViewStore from "../../stores/viewStore";
+import {togglePrettify} from "../../stores/viewStore/createViewFormattingSlice.ts";
 import {UI_ELEMENT} from "../../typings/states";
-import {HASH_PARAM_NAMES} from "../../typings/url";
 import {ACTION_NAME} from "../../utils/actions";
 import {isDisabled} from "../../utils/states";
-import {
-    copyPermalinkToClipboard,
-    updateWindowUrlHashParams,
-} from "../../utils/url";
-import {updateViewHashParams} from "../../utils/url/urlHash";
+import {copyPermalinkToClipboard} from "../../utils/url";
 import LogLevelSelect from "./LogLevelSelect";
 import StatusBarToggleButton from "./StatusBarToggleButton";
 
@@ -47,21 +44,9 @@ const StatusBar = () => {
     const numEvents = useLogFileStore((state) => state.numEvents);
     const uiState = useUiStore((state) => state.uiState);
 
-    const handleStatusButtonClick = useCallback((ev: React.MouseEvent<HTMLButtonElement>) => {
-        const {actionName} = ev.currentTarget.dataset;
-
-        switch (actionName) {
-            case ACTION_NAME.TOGGLE_PRETTIFY:
-                updateWindowUrlHashParams({
-                    [HASH_PARAM_NAMES.IS_PRETTIFIED]: false === isPrettified,
-                });
-                updateViewHashParams();
-                break;
-            default:
-                console.error(`Unexpected action: ${actionName}`);
-                break;
-        }
-    }, [isPrettified]);
+    const handlePrettifyToggle = useCallback(() => {
+        togglePrettify().catch(handleErrorWithNotification);
+    }, []);
 
     const isPrettifyButtonDisabled = isDisabled(uiState, UI_ELEMENT.PRETTIFY_BUTTON);
 
@@ -104,7 +89,7 @@ const StatusBar = () => {
                 tooltipTitle={false === isPrettified ?
                     "Turn on Prettify" :
                     "Turn off Prettify"}
-                onClick={handleStatusButtonClick}/>
+                onClick={handlePrettifyToggle}/>
         </Sheet>
     );
 };

--- a/src/components/StatusBar/index.tsx
+++ b/src/components/StatusBar/index.tsx
@@ -1,5 +1,3 @@
-import {useCallback} from "react";
-
 import {
     Button,
     Divider,
@@ -43,10 +41,6 @@ const StatusBar = () => {
     const numEvents = useLogFileStore((state) => state.numEvents);
     const uiState = useUiStore((state) => state.uiState);
 
-    const handlePrettifyToggle = useCallback(() => {
-        togglePrettify();
-    }, []);
-
     const isPrettifyButtonDisabled = isDisabled(uiState, UI_ELEMENT.PRETTIFY_BUTTON);
 
     return (
@@ -88,7 +82,7 @@ const StatusBar = () => {
                 tooltipTitle={false === isPrettified ?
                     "Turn on Prettify" :
                     "Turn off Prettify"}
-                onClick={handlePrettifyToggle}/>
+                onClick={togglePrettify}/>
         </Sheet>
     );
 };

--- a/src/stores/viewStore/createViewFormattingSlice.ts
+++ b/src/stores/viewStore/createViewFormattingSlice.ts
@@ -1,9 +1,5 @@
 import {StateCreator} from "zustand";
 
-import {HASH_PARAM_NAMES} from "../../typings/url";
-import {updateWindowUrlHashParams} from "../../utils/url";
-import {updateViewHashParams} from "../../utils/url/urlHash";
-import useViewStore from "./index";
 import {
     ViewFormattingSlice,
     ViewFormattingValues,
@@ -13,15 +9,6 @@ import {
 
 const VIEW_FORMATTING_DEFAULT: ViewFormattingValues = {
     isPrettified: false,
-};
-
-/**
- * Toggles the prettify state for formatted log viewing.
- */
-const togglePrettify = () => {
-    const {isPrettified} = useViewStore.getState();
-    updateWindowUrlHashParams({[HASH_PARAM_NAMES.IS_PRETTIFIED]: !isPrettified});
-    updateViewHashParams();
 };
 
 /**
@@ -39,5 +26,4 @@ const createViewFormattingSlice: StateCreator<
     },
 });
 
-export {togglePrettify};
 export default createViewFormattingSlice;

--- a/src/stores/viewStore/createViewFormattingSlice.ts
+++ b/src/stores/viewStore/createViewFormattingSlice.ts
@@ -1,12 +1,12 @@
 import {StateCreator} from "zustand";
 
-import {HASH_PARAM_NAMES} from "../../typings/url.ts";
-import {CURSOR_CODE} from "../../typings/worker.ts";
+import {HASH_PARAM_NAMES} from "../../typings/url";
+import {CURSOR_CODE} from "../../typings/worker";
 import {updateWindowUrlHashParams} from "../../utils/url";
-import {updateViewHashParams} from "../../utils/url/urlHash.ts";
-import useLogFileManagerProxyStore from "../logFileManagerProxyStore.ts";
-import {handleErrorWithNotification} from "../notificationStore.ts";
-import useViewStore from "./index.ts";
+import {updateViewHashParams} from "../../utils/url/urlHash";
+import useLogFileManagerProxyStore from "../logFileManagerProxyStore";
+import {handleErrorWithNotification} from "../notificationStore";
+import useViewStore from "./index";
 import {
     ViewFormattingSlice,
     ViewFormattingValues,

--- a/src/stores/viewStore/createViewFormattingSlice.ts
+++ b/src/stores/viewStore/createViewFormattingSlice.ts
@@ -21,26 +21,10 @@ const VIEW_FORMATTING_DEFAULT: ViewFormattingValues = {
 /**
  * Toggles the prettify state for formatted log viewing.
  */
-const togglePrettify = async () => {
-    const {logEventNum, loadPageByCursor, isPrettified, setIsPrettified} = useViewStore.getState();
-    const newIsPrettified = !isPrettified;
-
-    // Update the URL and store state.
-    updateWindowUrlHashParams({[HASH_PARAM_NAMES.IS_PRETTIFIED]: newIsPrettified});
-    setIsPrettified(newIsPrettified);
-
-    // Update the log file manager and reload the page.
-    try {
-        const {logFileManagerProxy} = useLogFileManagerProxyStore.getState();
-        await logFileManagerProxy.setIsPrettified(newIsPrettified);
-        await loadPageByCursor({
-            code: CURSOR_CODE.EVENT_NUM,
-            args: {eventNum: logEventNum},
-        });
-        updateViewHashParams();
-    } catch (error) {
-        handleErrorWithNotification(error);
-    }
+const togglePrettify = () => {
+    const {isPrettified} = useViewStore.getState();
+    updateWindowUrlHashParams({[HASH_PARAM_NAMES.IS_PRETTIFIED]: !isPrettified});
+    updateViewHashParams();
 };
 
 /**

--- a/src/stores/viewStore/createViewFormattingSlice.ts
+++ b/src/stores/viewStore/createViewFormattingSlice.ts
@@ -1,11 +1,8 @@
 import {StateCreator} from "zustand";
 
 import {HASH_PARAM_NAMES} from "../../typings/url";
-import {CURSOR_CODE} from "../../typings/worker";
 import {updateWindowUrlHashParams} from "../../utils/url";
 import {updateViewHashParams} from "../../utils/url/urlHash";
-import useLogFileManagerProxyStore from "../logFileManagerProxyStore";
-import {handleErrorWithNotification} from "../notificationStore";
 import useViewStore from "./index";
 import {
     ViewFormattingSlice,

--- a/src/utils/url/urlHash.ts
+++ b/src/utils/url/urlHash.ts
@@ -4,6 +4,7 @@ import {handleErrorWithNotification} from "../../stores/notificationStore";
 import useQueryStore from "../../stores/queryStore";
 import useViewStore from "../../stores/viewStore";
 import {Nullable} from "../../typings/common";
+import {HASH_PARAM_NAMES} from "../../typings/url";
 import {
     CURSOR_CODE,
     CursorType,
@@ -153,7 +154,17 @@ const updateQueryHashParams = () => {
     return isQueryModified;
 };
 
+/**
+ * Toggles the prettify state for formatted log viewing.
+ */
+const togglePrettify = () => {
+    const {isPrettified} = useViewStore.getState();
+    updateWindowUrlHashParams({[HASH_PARAM_NAMES.IS_PRETTIFIED]: !isPrettified});
+    updateViewHashParams();
+};
+
 export {
+    togglePrettify,
     updateQueryHashParams,
     updateViewHashParams,
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. Refactor `isPrettify` toggle handling into a helper function, which updates the UI visuals, URL parameters and triggers a page load.
2. Let both the toggle button and the editor "Toggle Prettify" action handler call the same helper.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Launched development server and tested the monaco editor action toggle as instructed by the reproduction steps in #379 :
1. Added `&isPrettified=true` to the URL in the address bar and observed the logs became formatted with spaces in between numbers.
2. Observed the "Pretty" button in the lower right corner became active as well.
3. Toggled the "Pretty" button so that it became inactive. Observed that the special formatting was removed from the logs in the editor.
4. Pressed `F1` to bring up the monaco editor's action menu. Typed `View: Toggle Prettify` and hit Enter. Observed the "Pretty" button became active and the URL parameter isPrettified=true was added, and the "Prettify" toggle button became active, and the log content in the monaco editor change format as expected.
5. Toggled the monaco action again as done in Step 4 and observed the URL parameter `isPrettified=true` was removed from the address bar, and the "Prettify" toggle button became inactive, and the log content in the monaco editor removed the special format as expected.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Unified the “Prettify” toggle into a single shared action used by the Editor and Status Bar to avoid duplicated logic.

- Bug Fixes
  - Improved reliability and sync of the “Prettify” toggle between the UI and URL/state handling.

- Documentation
  - Updated contributor/dev-guide testing notes to reflect three ways to toggle Prettify: status bar, address bar, and editor command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->