### PR TITLE
docs: Update broken link for datasets, changing `user-guide` path to `user-docs`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See the docs in our [developer guide][docs-site/dev-guide].
 [bug-report]: https://github.com/y-scope/yscope-log-viewer/issues/new?labels=bug&template=bug-report.yml
 [bugs-shield]: https://img.shields.io/github/issues/y-scope/yscope-log-viewer/bug?label=bugs
 [clp-repo]: https://github.com/y-scope/clp
-[datasets]: https://docs.yscope.com/clp/main/user-guide/resources-datasets
+[datasets]: https://docs.yscope.com/clp/main/user-docs/resources-datasets
 [docs-site]: https://docs.yscope.com/yscope-log-viewer/main/
 [docs-site/building]: https://docs.yscope.com/yscope-log-viewer/main/dev-guide/building-getting-started
 [docs-site/dev-guide]: https://docs.yscope.com/yscope-log-viewer/main/dev-guide/index

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -83,7 +83,7 @@ dev-guide/index
 [bug-report]: https://github.com/y-scope/yscope-log-viewer/issues/new?labels=bug&template=bug-report.yml
 [clp-loglib-py]: https://github.com/y-scope/clp-loglib-py
 [clp-repo]: https://github.com/y-scope/clp
-[datasets]: https://docs.yscope.com/clp/main/user-guide/resources-datasets
+[datasets]: https://docs.yscope.com/clp/main/user-docs/resources-datasets
 [feature-req]: https://github.com/y-scope/yscope-log-viewer/issues/new?labels=enhancement&template=feature-request.yml
 [hive-24hrs]: https://zenodo.org/records/7094921#.Y5JbH33MKHs
 [log4j1-appenders]: https://github.com/y-scope/log4j1-appenders


### PR DESCRIPTION

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The link to the CLP user guide has been changed to user-docs. The log viewer's documentation currently uses the old CLP user docs link to the dataset. This PR updates that broken link.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

The new link opens correctly.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated datasets documentation links to point to the correct “user-docs” resources page.
  - Ensures readers are directed to the current datasets resources, replacing outdated URLs.
  - No behavioural or feature changes; content clarity and navigation improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->