### PR TITLE
fix(editor): Correct key binding for toggle prettify action (fixes #386).

### DIFF
--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -74,7 +74,7 @@ const EDITOR_ACTIONS : EditorAction[] = [
     },
     {
         actionName: ACTION_NAME.TOGGLE_PRETTIFY,
-        keyBindings: [monaco.KeyMod.Alt | monaco.KeyCode.Shift | monaco.KeyCode.KeyF],
+        keyBindings: [monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyF],
         label: "View: Toggle Prettify",
     },
     {


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes the typo in specifying the "Shift" key modification code.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. In the editor view, pressed `F1` to bring up the Actions menu.
2. Typed `>prettify` and observed the key binding for the "View: Toggle Prettify" action now matched the desired binding `Shift` + `Alt` + `F`:
   <img width="884" height="126" alt="image" src="https://github.com/user-attachments/assets/5cfac9db-7783-406e-8982-8aeeeafa4ff7" />


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
