### PR TITLE
fix(export): Prevent OOM during large log exports by caching chunks as `Blob` objects.

### DIFF
--- a/src/services/LogExportManager.ts
+++ b/src/services/LogExportManager.ts
@@ -11,7 +11,7 @@ class LogExportManager {
     /**
      * Internal buffer which stores decoded chunks of log data.
      */
-    readonly #chunks: string[] = [];
+    readonly #chunks: Blob[] = [];
 
     /**
      * Total number of chunks to export.
@@ -42,7 +42,7 @@ class LogExportManager {
 
             return EXPORT_LOGS_PROGRESS_VALUE_MAX;
         }
-        this.#chunks.push(chunk);
+        this.#chunks.push(new Blob([chunk]));
         if (this.#chunks.length === this.#numChunks) {
             this.#download();
             this.#chunks.length = 0;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR stores exported chunks as Blob. The chunks were stored as string object before. This change allows for exporting larger files in Chrome. A slight increase in export speed is observed.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

IR files exports correctly.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improves reliability and speed of large log exports and downloads, reducing memory overhead and potential timeouts.
  * Smoother download experience for lengthy sessions.

* **Refactor**
  * Updated the internal buffering approach for exported logs to better handle large and mixed-content data without affecting existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->