### PR TITLE
refactor(url)!: Rename KQL filter param to `filter` and text search param to `search`.

### DIFF
--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/QueryInputBox.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/QueryInputBox.tsx
@@ -34,7 +34,7 @@ const QueryInputBox = () => {
 
     const handleQueryInputChange = useCallback((ev: React.ChangeEvent<HTMLTextAreaElement>) => {
         const newQueryString = ev.target.value;
-        updateWindowUrlHashParams({subquery: newQueryString});
+        updateWindowUrlHashParams({search: newQueryString});
         const {setQueryString, startQuery} = useQueryStore.getState();
         setQueryString(newQueryString);
         startQuery();

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/QueryInputBox.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/QueryInputBox.tsx
@@ -42,7 +42,7 @@ const QueryInputBox = () => {
 
     const handleCaseSensitivityButtonClick = useCallback(() => {
         const newQueryIsSensitive = !isCaseSensitive;
-        updateWindowUrlHashParams({queryIsCaseSensitive: newQueryIsSensitive});
+        updateWindowUrlHashParams({searchIsCaseSensitive: newQueryIsSensitive});
         const {setQueryIsCaseSensitive, startQuery} = useQueryStore.getState();
         setQueryIsCaseSensitive(newQueryIsSensitive);
         startQuery();
@@ -50,7 +50,7 @@ const QueryInputBox = () => {
 
     const handleRegexButtonClick = useCallback(() => {
         const newQueryIsRegex = !isRegex;
-        updateWindowUrlHashParams({queryIsRegex: newQueryIsRegex});
+        updateWindowUrlHashParams({searchIsRegex: newQueryIsRegex});
         const {setQueryIsRegex, startQuery} = useQueryStore.getState();
         setQueryIsRegex(newQueryIsRegex);
         startQuery();

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
@@ -68,9 +68,9 @@ const SearchTabPanel = () => {
         copyPermalinkToClipboard({}, {
             filter: kqlFilterInput,
             logEventNum: URL_HASH_PARAMS_DEFAULT.logEventNum,
+            search: queryString,
             searchIsCaseSensitive: queryIsCaseSensitive,
             searchIsRegex: queryIsRegex,
-            search: queryString,
         });
     }, []);
 

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
@@ -66,11 +66,11 @@ const SearchTabPanel = () => {
         setQueryString(queryString);
 
         copyPermalinkToClipboard({}, {
+            filter: kqlFilterInput,
             logEventNum: URL_HASH_PARAMS_DEFAULT.logEventNum,
-            query: kqlFilterInput,
             queryIsCaseSensitive: queryIsCaseSensitive,
             queryIsRegex: queryIsRegex,
-            subquery: queryString,
+            search: queryString,
         });
     }, []);
 

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/SearchTabPanel/index.tsx
@@ -68,8 +68,8 @@ const SearchTabPanel = () => {
         copyPermalinkToClipboard({}, {
             filter: kqlFilterInput,
             logEventNum: URL_HASH_PARAMS_DEFAULT.logEventNum,
-            queryIsCaseSensitive: queryIsCaseSensitive,
-            queryIsRegex: queryIsRegex,
+            searchIsCaseSensitive: queryIsCaseSensitive,
+            searchIsRegex: queryIsRegex,
             search: queryString,
         });
     }, []);

--- a/src/stores/viewStore/createViewFilterSlice.ts
+++ b/src/stores/viewStore/createViewFilterSlice.ts
@@ -31,7 +31,7 @@ const createViewFilterSlice: StateCreator<ViewState, [], [], ViewFilterSlice> = 
             const {logFileManagerProxy} = useLogFileManagerStore.getState();
             await logFileManagerProxy.setFilter(logLevelFilter, kqlFilter);
 
-            updateWindowUrlHashParams({query: kqlFilter});
+            updateWindowUrlHashParams({filter: kqlFilter});
         })().catch(handleErrorWithNotification);
     },
     setKqlFilter: (newValue) => {

--- a/src/typings/url.ts
+++ b/src/typings/url.ts
@@ -6,12 +6,12 @@ enum SEARCH_PARAM_NAMES {
 }
 
 enum HASH_PARAM_NAMES {
-    FILTER_STRING = "filter",
+    FILTER = "filter",
     IS_PRETTIFIED = "isPrettified",
     LOG_EVENT_NUM = "logEventNum",
-    QUERY_IS_CASE_SENSITIVE = "searchIsCaseSensitive",
-    QUERY_IS_REGEX = "searchIsRegex",
-    QUERY_STRING = "search",
+    SEARCH_IS_CASE_SENSITIVE = "searchIsCaseSensitive",
+    SEARCH_IS_REGEX = "searchIsRegex",
+    SEARCH_STRING = "search",
     TIMESTAMP = "timestamp",
 }
 
@@ -20,12 +20,12 @@ interface UrlSearchParams {
 }
 
 interface UrlHashParams {
-    [HASH_PARAM_NAMES.FILTER_STRING]: string;
+    [HASH_PARAM_NAMES.FILTER]: string;
     [HASH_PARAM_NAMES.IS_PRETTIFIED]: boolean;
     [HASH_PARAM_NAMES.LOG_EVENT_NUM]: number;
-    [HASH_PARAM_NAMES.QUERY_IS_CASE_SENSITIVE]: boolean;
-    [HASH_PARAM_NAMES.QUERY_IS_REGEX]: boolean;
-    [HASH_PARAM_NAMES.QUERY_STRING]: string;
+    [HASH_PARAM_NAMES.SEARCH_IS_CASE_SENSITIVE]: boolean;
+    [HASH_PARAM_NAMES.SEARCH_IS_REGEX]: boolean;
+    [HASH_PARAM_NAMES.SEARCH_STRING]: string;
     [HASH_PARAM_NAMES.TIMESTAMP]: number;
 }
 

--- a/src/typings/url.ts
+++ b/src/typings/url.ts
@@ -6,12 +6,12 @@ enum SEARCH_PARAM_NAMES {
 }
 
 enum HASH_PARAM_NAMES {
-    FILTER_STRING = "query",
+    FILTER_STRING = "filter",
     IS_PRETTIFIED = "isPrettified",
     LOG_EVENT_NUM = "logEventNum",
     QUERY_IS_CASE_SENSITIVE = "queryIsCaseSensitive",
     QUERY_IS_REGEX = "queryIsRegex",
-    QUERY_STRING = "subquery",
+    QUERY_STRING = "search",
     TIMESTAMP = "timestamp",
 }
 

--- a/src/typings/url.ts
+++ b/src/typings/url.ts
@@ -9,8 +9,8 @@ enum HASH_PARAM_NAMES {
     FILTER_STRING = "filter",
     IS_PRETTIFIED = "isPrettified",
     LOG_EVENT_NUM = "logEventNum",
-    QUERY_IS_CASE_SENSITIVE = "queryIsCaseSensitive",
-    QUERY_IS_REGEX = "queryIsRegex",
+    QUERY_IS_CASE_SENSITIVE = "searchIsCaseSensitive",
+    QUERY_IS_REGEX = "searchIsRegex",
     QUERY_STRING = "search",
     TIMESTAMP = "timestamp",
 }

--- a/src/utils/url/index.ts
+++ b/src/utils/url/index.ts
@@ -24,12 +24,12 @@ const URL_SEARCH_PARAMS_DEFAULT = Object.freeze({
  * Default values of the hash parameters.
  */
 const URL_HASH_PARAMS_DEFAULT = Object.freeze({
-    [HASH_PARAM_NAMES.FILTER_STRING]: "",
+    [HASH_PARAM_NAMES.FILTER]: "",
     [HASH_PARAM_NAMES.IS_PRETTIFIED]: false,
     [HASH_PARAM_NAMES.LOG_EVENT_NUM]: 0,
-    [HASH_PARAM_NAMES.QUERY_IS_CASE_SENSITIVE]: false,
-    [HASH_PARAM_NAMES.QUERY_IS_REGEX]: false,
-    [HASH_PARAM_NAMES.QUERY_STRING]: "",
+    [HASH_PARAM_NAMES.SEARCH_IS_CASE_SENSITIVE]: false,
+    [HASH_PARAM_NAMES.SEARCH_IS_REGEX]: false,
+    [HASH_PARAM_NAMES.SEARCH_STRING]: "",
     [HASH_PARAM_NAMES.TIMESTAMP]: -1,
 });
 
@@ -189,14 +189,14 @@ const parseWindowUrlHashParams = (): Partial<UrlHashParams> => {
             case HASH_PARAM_NAMES.QUERY_IS_CASE_SENSITIVE:
 
                 // Fall through
-            case HASH_PARAM_NAMES.QUERY_IS_REGEX:
+            case HASH_PARAM_NAMES.SEARCH_IS_REGEX:
                 parsedHashParams[key] = "true" === value;
                 break;
 
-            case HASH_PARAM_NAMES.FILTER_STRING:
+            case HASH_PARAM_NAMES.FILTER:
                 parsedHashParams[key] = value;
                 break;
-            case HASH_PARAM_NAMES.QUERY_STRING:
+            case HASH_PARAM_NAMES.SEARCH_STRING:
                 parsedHashParams[key] = value;
                 break;
             default:

--- a/src/utils/url/urlHash.ts
+++ b/src/utils/url/urlHash.ts
@@ -151,8 +151,8 @@ const updateViewHashParams = () => {
  * @return Whether any query-related parameters were modified.
  */
 const updateQueryHashParams = () => {
-    const {queryIsCaseSensitive, queryIsRegex, search} = getWindowUrlHashParams();
-    updateWindowUrlHashParams({queryIsCaseSensitive, queryIsRegex, search});
+    const {searchIsCaseSensitive, searchIsRegex, search} = getWindowUrlHashParams();
+    updateWindowUrlHashParams({ searchIsCaseSensitive, searchIsRegex, search});
 
     const {
         queryIsCaseSensitive: currentQueryIsCaseSensitive,
@@ -164,11 +164,11 @@ const updateQueryHashParams = () => {
     } = useQueryStore.getState();
 
     let isQueryModified = false;
-    isQueryModified ||= queryIsCaseSensitive !== currentQueryIsCaseSensitive;
-    setQueryIsCaseSensitive(queryIsCaseSensitive);
+    isQueryModified ||= searchIsCaseSensitive !== currentQueryIsCaseSensitive;
+    setQueryIsCaseSensitive(searchIsCaseSensitive);
 
-    isQueryModified ||= queryIsRegex !== currentQueryIsRegex;
-    setQueryIsRegex(queryIsRegex);
+    isQueryModified ||= searchIsRegex !== currentQueryIsRegex;
+    setQueryIsRegex(searchIsRegex);
 
     isQueryModified ||= search !== currentQueryString;
     setQueryString(search);

--- a/src/utils/url/urlHash.ts
+++ b/src/utils/url/urlHash.ts
@@ -151,7 +151,7 @@ const updateViewHashParams = () => {
  * @return Whether any query-related parameters were modified.
  */
 const updateQueryHashParams = () => {
-    const {searchIsCaseSensitive, searchIsRegex, search} = getWindowUrlHashParams();
+    const {search, searchIsCaseSensitive, searchIsRegex} = getWindowUrlHashParams();
     updateWindowUrlHashParams({searchIsCaseSensitive, searchIsRegex, search});
 
     const {

--- a/src/utils/url/urlHash.ts
+++ b/src/utils/url/urlHash.ts
@@ -107,7 +107,7 @@ const getCursorFromHashParams = ({isPrettified, logEventNum, timestamp}: {
  * @return Whether any query-related parameters were modified.
  */
 const updateViewHashParams = () => {
-    const {isPrettified, logEventNum, filter, timestamp} = getWindowUrlHashParams();
+    const {filter, isPrettified, logEventNum, timestamp} = getWindowUrlHashParams();
     updateWindowUrlHashParams({
         filter: filter,
         isPrettified: isPrettified,

--- a/src/utils/url/urlHash.ts
+++ b/src/utils/url/urlHash.ts
@@ -152,7 +152,7 @@ const updateViewHashParams = () => {
  */
 const updateQueryHashParams = () => {
     const {search, searchIsCaseSensitive, searchIsRegex} = getWindowUrlHashParams();
-    updateWindowUrlHashParams({searchIsCaseSensitive, searchIsRegex, search});
+    updateWindowUrlHashParams({search, searchIsCaseSensitive, searchIsRegex});
 
     const {
         queryIsCaseSensitive: currentQueryIsCaseSensitive,
@@ -164,14 +164,14 @@ const updateQueryHashParams = () => {
     } = useQueryStore.getState();
 
     let isQueryModified = false;
+    isQueryModified ||= search !== currentQueryString;
+    setQueryString(search);
+
     isQueryModified ||= searchIsCaseSensitive !== currentQueryIsCaseSensitive;
     setQueryIsCaseSensitive(searchIsCaseSensitive);
 
     isQueryModified ||= searchIsRegex !== currentQueryIsRegex;
     setQueryIsRegex(searchIsRegex);
-
-    isQueryModified ||= search !== currentQueryString;
-    setQueryString(search);
 
     return isQueryModified;
 };

--- a/src/utils/url/urlHash.ts
+++ b/src/utils/url/urlHash.ts
@@ -152,7 +152,7 @@ const updateViewHashParams = () => {
  */
 const updateQueryHashParams = () => {
     const {searchIsCaseSensitive, searchIsRegex, search} = getWindowUrlHashParams();
-    updateWindowUrlHashParams({ searchIsCaseSensitive, searchIsRegex, search});
+    updateWindowUrlHashParams({searchIsCaseSensitive, searchIsRegex, search});
 
     const {
         queryIsCaseSensitive: currentQueryIsCaseSensitive,

--- a/src/utils/url/urlHash.ts
+++ b/src/utils/url/urlHash.ts
@@ -107,9 +107,9 @@ const getCursorFromHashParams = ({isPrettified, logEventNum, timestamp}: {
  * @return Whether any query-related parameters were modified.
  */
 const updateViewHashParams = () => {
-    const {isPrettified, logEventNum, query, timestamp} = getWindowUrlHashParams();
+    const {isPrettified, logEventNum, filter, timestamp} = getWindowUrlHashParams();
     updateWindowUrlHashParams({
-        query: query,
+        filter: filter,
         isPrettified: isPrettified,
         timestamp: URL_HASH_PARAMS_DEFAULT.timestamp,
     });
@@ -123,11 +123,11 @@ const updateViewHashParams = () => {
     } = useViewStore.getState();
 
     let isQueryModified = false;
-    if (query !== kqlFilter) {
+    if (filter !== kqlFilter) {
         if (kqlFilter === kqlFilterInput) {
-            setKqlFilterInput(query);
+            setKqlFilterInput(filter);
         }
-        setKqlFilter(query);
+        setKqlFilter(filter);
         filterLogs();
         isQueryModified = true;
     }
@@ -151,8 +151,8 @@ const updateViewHashParams = () => {
  * @return Whether any query-related parameters were modified.
  */
 const updateQueryHashParams = () => {
-    const {queryIsCaseSensitive, queryIsRegex, subquery} = getWindowUrlHashParams();
-    updateWindowUrlHashParams({queryIsCaseSensitive, queryIsRegex, subquery});
+    const {queryIsCaseSensitive, queryIsRegex, search} = getWindowUrlHashParams();
+    updateWindowUrlHashParams({queryIsCaseSensitive, queryIsRegex, search});
 
     const {
         queryIsCaseSensitive: currentQueryIsCaseSensitive,
@@ -170,8 +170,8 @@ const updateQueryHashParams = () => {
     isQueryModified ||= queryIsRegex !== currentQueryIsRegex;
     setQueryIsRegex(queryIsRegex);
 
-    isQueryModified ||= subquery !== currentQueryString;
-    setQueryString(subquery);
+    isQueryModified ||= search !== currentQueryString;
+    setQueryString(search);
 
     return isQueryModified;
 };


### PR DESCRIPTION


<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR renames KQL filter parameter to `filter` and text search parameter to `search`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

New parameter names are set and read in the url.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed URL hash parameters: subquery → search, query → filter, queryIsCaseSensitive → searchIsCaseSensitive, queryIsRegex → searchIsRegex for consistent naming.
  * Share/permalink payload now uses the updated search/filter fields and includes the new filter field; case‑sensitivity and regex toggles retained under new names.
  * No change to user-visible behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->