### PR TITLE
fix(url): Reload page on KQL filter parameter change (fixes #401).

### DIFF
--- a/src/utils/url/urlHash.ts
+++ b/src/utils/url/urlHash.ts
@@ -132,7 +132,18 @@ const updateViewHashParams = () => {
         isQueryModified = true;
     }
 
-    const cursor = getCursorFromHashParams({isPrettified, logEventNum, timestamp});
+    let cursor = getCursorFromHashParams({isPrettified, logEventNum, timestamp});
+
+    if (filter !== kqlFilter) {
+        // The log viewer needs to reload the page if the KQL filter is updated, even if
+        // the log event is on the current page.
+        // This could cause a double page load if query parameters are also being changed.
+        cursor = {
+            code: CURSOR_CODE.EVENT_NUM,
+            args: {eventNum: logEventNum},
+        };
+    }
+
     if (null === cursor) {
         // If no cursor was set, we can return early.
         return isQueryModified;

--- a/src/utils/url/urlHash.ts
+++ b/src/utils/url/urlHash.ts
@@ -134,19 +134,19 @@ const updateViewHashParams = () => {
 
     let cursor = getCursorFromHashParams({isPrettified, logEventNum, timestamp});
 
-    if (filter !== kqlFilter) {
-        // The log viewer needs to reload the page if the KQL filter is updated, even if
-        // the log event is on the current page.
-        // This could cause a double page load if query parameters are also being changed.
-        cursor = {
-            code: CURSOR_CODE.EVENT_NUM,
-            args: {eventNum: logEventNum},
-        };
-    }
-
     if (null === cursor) {
-        // If no cursor was set, we can return early.
-        return isQueryModified;
+        if (filter !== kqlFilter) {
+            // The log viewer needs to reload the page if the KQL filter is updated, even if
+            // the log event is on the current page.
+            // This could cause a double page load if query parameters are also being changed.
+            cursor = {
+                code: CURSOR_CODE.EVENT_NUM,
+                args: {eventNum: logEventNum},
+            };
+        } else {
+            // If no cursor was set, we can return early.
+            return isQueryModified;
+        }
     }
 
     const {loadPageByCursor} = useViewStore.getState();


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR reloads the page whenever the filter parameter changes. This is a hot fix as it could result in a double page load.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
1. #401 is fixed.
2. other url params still work.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page navigation when KQL filter parameters change: the app now forces a reload to ensure the correct log event is displayed after filter updates, even if the event was already visible. This preserves existing behavior for other navigation cases while ensuring consistent results after filter edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->