### PR TITLE
fix(decoder): Auto-detect timestamp resolution in JSONL decoder

### DIFF
--- a/src/services/decoders/JsonlDecoder/utils.ts
+++ b/src/services/decoders/JsonlDecoder/utils.ts
@@ -10,6 +10,18 @@ import {
 } from "../../../typings/logs";
 
 
+// Timestamp resolution detection thresholds
+const TIMESTAMP_THRESHOLD_SECONDS = 1e11;
+const TIMESTAMP_THRESHOLD_MILLISECONDS = 1e14;
+const TIMESTAMP_THRESHOLD_MICROSECONDS = 1e17;
+
+// Conversion factors to milliseconds
+const MILLISECONDS_PER_SECOND = 1000;
+const MILLISECONDS_PER_MICROSECOND = 1000;
+const MILLISECONDS_PER_NANOSECOND = 1e6;
+const NANOSECONDS_PER_MILLISECOND = 1000000n;
+
+
 /**
  * Determines whether the given value is a `JsonObject` and applies a TypeScript narrowing
  * conversion if so.
@@ -73,25 +85,30 @@ const convertToDayjsTimestamp = (field: JsonValue | bigint | undefined): dayjs.D
 
     // Auto-detect timestamp resolution and convert to milliseconds
     if ("number" === typeof field || "bigint" === typeof field) {
-        const numValue = "bigint" === typeof field ? Number(field) : field;
+        const numValue = "bigint" === typeof field
+            ? Number(field)
+            : field;
 
         // Detection based on timestamp magnitude:
         // - Seconds: < 10^11 (covers dates up to year 5138)
         // - Milliseconds: 10^11 <= t < 10^14
         // - Microseconds: 10^14 <= t < 10^17
         // - Nanoseconds: >= 10^17
-        if (numValue < 1e11) {
+        if (numValue < TIMESTAMP_THRESHOLD_SECONDS && numValue >= 0) {
             // Seconds -> convert to milliseconds
-            timestampInMs = numValue * 1000;
-        } else if (numValue < 1e14) {
+            timestampInMs = numValue * MILLISECONDS_PER_SECOND;
+        } else if (numValue < TIMESTAMP_THRESHOLD_MILLISECONDS) {
             // Milliseconds -> use as-is
             timestampInMs = numValue;
-        } else if (numValue < 1e17) {
+        } else if (numValue < TIMESTAMP_THRESHOLD_MICROSECONDS) {
             // Microseconds -> convert to milliseconds
-            timestampInMs = numValue / 1000;
+            timestampInMs = numValue / MILLISECONDS_PER_MICROSECOND;
         } else {
             // Nanoseconds -> convert to milliseconds
-            timestampInMs = numValue / 1e6;
+            // For bigint, perform division before converting to avoid precision loss
+            timestampInMs = "bigint" === typeof field
+                ? Number(field / NANOSECONDS_PER_MILLISECOND)
+                : numValue / MILLISECONDS_PER_NANOSECOND;
         }
     }
 


### PR DESCRIPTION
## Description

This PR enhances the JSONL decoder’s `convertToDayjsTimestamp` function by adding automatic timestamp resolution detection. Previously, the function assumed millisecond precision, leading to incorrect parsing for logs using seconds, microseconds, or nanoseconds.

The updated implementation infers resolution based on magnitude:

- **Seconds** (< 10¹¹): multiplied by 1,000  
- **Milliseconds** (10¹¹–10¹⁴): used as-is  
- **Microseconds** (10¹⁴–10¹⁷): divided by 1,000  
- **Nanoseconds** (≥ 10¹⁷): divided by 1,000,000  

This ensures `dayjs.utc()` receives a properly scaled millisecond input, improving compatibility across diverse log formats.

## Checklist

- [x] PR complies with [contribution guidelines][yscope-contrib-guidelines]  
- [x] Not a breaking change, or marked accordingly  
- [x] Docs updated if needed

## Validation

Before the fix: `{timestamp:timestamp}` rendered incorrectly as `1970-01-01T00:00:00Z`  
![Before](https://github.com/user-attachments/assets/09897ad5-1c7c-4217-9d1a-bd409cdc9c10)

After the fix: `{timestamp:timestamp}` correctly renders as `2023-03-25T02:43:46Z`  
![After](https://github.com/user-attachments/assets/332c3ef1-408b-4f16-aa0a-b315fb198871)

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides/overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp parsing for JSONL imports to auto-detect numeric timestamp precision (seconds, milliseconds, microseconds, nanoseconds) and normalise values to a consistent millisecond-based format. This reduces parsing errors and improves compatibility when importing datasets that use varying timestamp resolutions, while preserving existing invalid-timestamp handling and validation behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->