### PR TITLE
fix(ci): Replace `npm install -g @go-task/cli` with `go-task/setup-task` action to eliminate npm supply-chain risk; Use reusable CI actions from `yscope-dev-utils`; Bump `actions/checkout` to v6.0.2.

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ jobs:
       STYLELINT_MATCHER_OWNER: "stylelint"
       STYLELINT_MATCHER_PATH: "./.github/problem-matchers/stylelint.json"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           persist-credentials: false
           submodules: "recursive"

--- a/.github/workflows/log-viewer-docs.yaml
+++ b/.github/workflows/log-viewer-docs.yaml
@@ -40,8 +40,9 @@ jobs:
           python-version: "3.10"
 
       - name: "Install task"
-        shell: "bash"
-        run: "npm install -g @go-task/cli"
+        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
+        with:
+          version: "3.48.0"
 
       - if: "matrix.os == 'macos-latest'"
         name: "Install coreutils (for md5sum)"

--- a/.github/workflows/log-viewer-docs.yaml
+++ b/.github/workflows/log-viewer-docs.yaml
@@ -30,23 +30,18 @@ jobs:
         os: ["macos-latest", "ubuntu-latest"]
     runs-on: "${{matrix.os}}"
     steps:
-      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           lfs: "true"
           submodules: "recursive"
 
-      - uses: "actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38"
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-python"
         with:
-          python-version: "3.10"
+          version: "3.10"
 
-      - name: "Install task"
-        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
         with:
           version: "3.48.0"
-
-      - if: "matrix.os == 'macos-latest'"
-        name: "Install coreutils (for md5sum)"
-        run: "brew install coreutils"
 
       - name: "Build docs"
         shell: "bash"

--- a/.github/workflows/log-viewer-docs.yaml
+++ b/.github/workflows/log-viewer-docs.yaml
@@ -40,8 +40,6 @@ jobs:
           version: "3.10"
 
       - uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
-        with:
-          version: "3.48.0"
 
       - name: "Build docs"
         shell: "bash"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       VERSION: "${{steps.names.outputs.VERSION}}"
       VERSIONED_DIST_NAME: "${{steps.names.outputs.VERSIONED_DIST_NAME}}"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           persist-credentials: false
           submodules: "recursive"
@@ -78,7 +78,7 @@ jobs:
       # To create a release
       contents: "write"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           persist-credentials: false
           submodules: "recursive"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
   test:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           persist-credentials: false
           submodules: "recursive"

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,8 @@ this project:
   * We use Git LFS to store the images in the docs; this is to avoid significant increases in
     the size of repo as we add and update images.
 * [Node.js] >= 16 to be able to [view the output](#viewing-the-output)
-* Python 3.10 or later
-* [Task] >= 3.40.0
+* Python >= 3.10
+* [Task] >= 3.49.1
 
 ## Build commands
 

--- a/docs/tasks.yaml
+++ b/docs/tasks.yaml
@@ -56,7 +56,7 @@ tasks:
           INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     sources:
       - "{{.G_DOCS_VENV_CHECKSUM_FILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
+      - "{{.ROOT_TASKFILE}}"
       - "{{.TASKFILE}}"
       - "conf/**/*"
       - "src/**/*"
@@ -87,7 +87,7 @@ tasks:
           INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     sources:
       - "{{.REQUIREMENTS_FILE}}"
-      - "{{.ROOT_DIR}}/taskfile.yaml"
+      - "{{.ROOT_TASKFILE}}"
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]
 
@@ -111,6 +111,6 @@ tasks:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     sources:
-      - "{{.ROOT_DIR}}/taskfile.yaml"
+      - "{{.ROOT_TASKFILE}}"
       - "{{.TASKFILE}}"
     generates: ["{{.CHECKSUM_FILE}}"]


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

All CI workflows install the Task runner via `npm install -g @go-task/cli`. `@go-task/cli` declares
a transitive dependency on `axios: ^1.8.2`, and because global npm installs have no lock file, npm
resolves to whatever the latest semver-compatible version is at install time. During the
[axios supply-chain compromise on 2026-03-31][axios-advisory], this caused CI runners to pull in the
malicious `axios@1.14.1` package, which executed a post-install script that connected to an
attacker-controlled C2 server.

This PR:
1. Replaces `npm install -g @go-task/cli` with the official [`go-task/setup-task`][setup-task]
   GitHub Action, pinned by commit SHA. The action downloads the Task binary directly from GitHub
   Releases without involving npm, eliminating the transitive dependency on axios and the broader npm
   supply-chain attack surface.
2. Replaces inline `actions/setup-python`, `go-task/setup-task`, and the standalone `coreutils`
   install step in `log-viewer-docs.yaml` with reusable CI actions from
   [`yscope-dev-utils`][yscope-dev-utils] (the `install-python` and `install-go-task` composite
   actions). The `install-go-task` action already handles the macOS `coreutils` installation
   internally, so the separate step is no longer needed.
3. Bumps `actions/checkout` from unpinned `v4` / old SHA to
   `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) across all workflows (`lint.yaml`,
   `log-viewer-docs.yaml`, `release.yaml`, `test.yaml`).
4. Updates `tools/yscope-dev-utils` submodule to `2facad83` which contains the reusable CI actions.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

1. Verified that no `npm install -g` commands remain in any workflow file.
2. Confirmed the pinned commit SHA `3be4020d41929789a01026e0e427a4321ce0ad44` corresponds to
   `go-task/setup-task` [v2.0.0][setup-task-v2].
3. Verified that `actions/checkout` is pinned to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
   in all workflow files.
4. Verified that `yscope-dev-utils` composite actions (`install-python`, `install-go-task`) are
   correctly referenced from `./tools/yscope-dev-utils/exports/github/actions/`.
5. Verified that the `install-go-task` action includes the macOS `coreutils` installation step,
   making the standalone step in `log-viewer-docs.yaml` redundant.

[axios-advisory]: https://github.com/advisories/GHSA-fw8c-xr5c-95f9
[setup-task]: https://github.com/go-task/setup-task
[setup-task-v2]: https://github.com/go-task/setup-task/releases/tag/v2.0.0
[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
[yscope-dev-utils]: https://github.com/y-scope/yscope-dev-utils

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned checkout action across CI/CD workflows for greater stability and consistency
  * Swapped some remote setup steps for repo-local setup steps; removed a couple of global tool installs
  * Updated development tooling submodule reference

* **Documentation**
  * Clarified environment prerequisites (Python constraint and raised Task minimum)
  * Adjusted internal task source references used by the docs build system
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
