### PR TITLE
fix(url): Rename stale `QUERY_IS_CASE_SENSITIVE` to `SEARCH_IS_CASE_SENSITIVE` in switch case (fixes #411).

### DIFF
--- a/src/utils/url/index.ts
+++ b/src/utils/url/index.ts
@@ -186,7 +186,7 @@ const parseWindowUrlHashParams = (): Partial<UrlHashParams> => {
             case HASH_PARAM_NAMES.IS_PRETTIFIED:
 
                 // Fall through
-            case HASH_PARAM_NAMES.QUERY_IS_CASE_SENSITIVE:
+            case HASH_PARAM_NAMES.SEARCH_IS_CASE_SENSITIVE:
 
                 // Fall through
             case HASH_PARAM_NAMES.SEARCH_IS_REGEX:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

PR #403 renamed the `QUERY_IS_CASE_SENSITIVE` enum member to `SEARCH_IS_CASE_SENSITIVE` in `src/typings/url.ts`, but missed the corresponding switch case in `parseWindowUrlHashParams()`. As a result, the `case HASH_PARAM_NAMES.QUERY_IS_CASE_SENSITIVE:` label referenced a non-existent enum value, causing the `searchIsCaseSensitive` hash parameter to silently fall through to `default` and be ignored when parsing the URL.

This PR updates the stale reference at https://github.com/y-scope/yscope-log-viewer/blob/3d52dedd1e8bfc7a7053651d1c4b0bf88ab7ef0c/src/utils/url/index.ts#L189 to use `HASH_PARAM_NAMES.SEARCH_IS_CASE_SENSITIVE`, matching the enum definition at https://github.com/y-scope/yscope-log-viewer/blob/3d52dedd1e8bfc7a7053651d1c4b0bf88ab7ef0c/src/typings/url.ts#L12.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Started dev server and loaded http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst#logEventNum=1&search=STARTUP (which performs search with string "STARTUP")
2. Clicked the case sensitivity toggle in the Search tab and observed result that matched "Startup" disappeared.
3. Inspected the URL link and found `searchIsCaseSensitive=true` in http://localhost:3010/?filePath=https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst#logEventNum=1&search=STARTUP&searchIsCaseSensitive=true
4. Refreshed browser page and found the case sensitivity config was preserved.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed URL parameter parsing for case-sensitive search functionality to ensure the correct parameter is interpreted in search operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->