### PR TITLE
feat(FileInfoTabPanel): Display file type name in the file info tab panel (resolves #409).

### DIFF
--- a/src/components/CentralContainer/Sidebar/SidebarTabs/FileInfoTabPanel/index.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/FileInfoTabPanel/index.tsx
@@ -6,6 +6,7 @@ import {
 } from "@mui/joy";
 
 import AbcIcon from "@mui/icons-material/Abc";
+import DataObjectIcon from "@mui/icons-material/DataObject";
 import StorageIcon from "@mui/icons-material/Storage";
 
 import useLogFileStore from "../../../../../stores/logFileStore";
@@ -20,12 +21,13 @@ import MetadataListItem from "./MetadataListItem";
 
 
 /**
- * Displays a panel containing the file name and on-disk size of the selected file.
+ * Displays a panel containing the file name, file type, on-disk size, and metadata
  *
  * @return
  */
 const FileInfoTabPanel = () => {
     const fileName = useLogFileStore((state) => state.fileName);
+    const fileTypeInfo = useLogFileStore((state) => state.fileTypeInfo);
     const onDiskFileSizeInBytes = useLogFileStore((state) => state.onDiskFileSizeInBytes);
 
     const isFileUnloaded = 0 === fileName.length;
@@ -47,6 +49,11 @@ const FileInfoTabPanel = () => {
                         icon={<AbcIcon/>}
                         slotProps={{content: {sx: {wordBreak: "break-word"}}}}
                         title={"Name"}/>
+                    <Divider/>
+                    <CustomListItem
+                        content={fileTypeInfo?.name ?? ""}
+                        icon={<DataObjectIcon/>}
+                        title={"File Type"}/>
                     <Divider/>
                     <CustomListItem
                         content={formattedOnDiskSize}

--- a/src/components/CentralContainer/Sidebar/SidebarTabs/FileInfoTabPanel/index.tsx
+++ b/src/components/CentralContainer/Sidebar/SidebarTabs/FileInfoTabPanel/index.tsx
@@ -51,7 +51,7 @@ const FileInfoTabPanel = () => {
                         title={"Name"}/>
                     <Divider/>
                     <CustomListItem
-                        content={fileTypeInfo?.name ?? ""}
+                        content={fileTypeInfo?.name ?? "Unknown"}
                         icon={<DataObjectIcon/>}
                         title={"File Type"}/>
                     <Divider/>


### PR DESCRIPTION
# Description

Add a "File Type" item to the `FileInfoTabPanel` that displays the `fileTypeInfo.name` value (e.g. "CLP IR", "JSON Lines", "Plain Text") from the log file store. The `fileTypeInfo` data was already available in the store but was only consumed by `SearchTabPanel` and `QueryInputBox` for toggling KQL filtering — it was never displayed to the user.

**Changes:**

- Add a `CustomListItem` for "File Type" between "Name" and "On-disk Size" in https://github.com/y-scope/yscope-log-viewer/blob/3d52dedd1e8bfc7a7053651d1c4b0bf88ab7ef0c/src/components/CentralContainer/Sidebar/SidebarTabs/FileInfoTabPanel/index.tsx#L53-L56
- Import `DataObjectIcon` from `@mui/icons-material/DataObject` for the file type item's icon
- Add a `fileTypeInfo` store selector to read the file type name from the Zustand store

# Impact Assessment

This change is limited to the `FileInfoTabPanel` component's UI rendering. It adds a read-only display of existing store data (`fileTypeInfo.name`) — no state mutations, API calls, or behavioral changes. When no file is loaded, the entire list is hidden behind the "No file is open." message, so the null-safe access (`fileTypeInfo?.name ?? ""`) handles the edge case gracefully.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

1. `npm run build`
   - **Output**: Build succeeded with no errors.
   - **Explanation**: Confirms no type errors or build failures from the new store selector and JSX additions.

2. `npx eslint src/components/CentralContainer/Sidebar/SidebarTabs/FileInfoTabPanel/index.tsx`
   - **Output**: No lint errors.
   - **Explanation**: Confirms the new import, store selector, and JSX adhere to the project's lint rules.

3. `npm run dev` — Load a `.clp.zst` file
   - **Observation**: The "File info" tab panel displays "File Type: CLP IR" between the "Name" and "On-disk Size" items.

4. Load a `.jsonl` file
   - **Observation**: The "File info" tab panel displays "File Type: JSON Lines".

5. Load a `.log` file
   - **Observation**: The "File info" tab panel displays "File Type: Plain Text".

6. With no file loaded
   - **Observation**: The "File info" tab panel displays "No file is open." — no empty "File Type" row is shown.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File information panel now displays file type information, providing more complete file metadata details to users when viewing open files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/y-scope/yscope-log-viewer/pull/423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->